### PR TITLE
Update bazelisk to latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,11 @@ deb [arch=amd64] https://downloads.apache.org/cassandra/debian 311x main
 Note that Redhat variants like Amazon Linux 2 avoid this issue. In our out of box Cassandra performance testing (early July 2020), Amazon Linux 2 using [the Corretto 8 JDK](https://docs.aws.amazon.com/corretto/latest/corretto-8-ug/amazon-linux-install.html) outperformed Ubuntu 20.04 by up to 23%.
 
 ## Bazel on Linux
-The [Bazel build tool](https://www.bazel.build/) now releases a pre-built binary for arm64. As of August 2020, this is not available in their custom Debian repo, and Bazel does not officially provide an RPM. Instead, we recommend using the [Bazelisk installer](https://docs.bazel.build/versions/master/install-bazelisk.html), which will replace your `bazel` command and [keep bazel up to date](https://github.com/bazelbuild/bazelisk/blob/master/README.md).
+The [Bazel build tool](https://www.bazel.build/) now releases a pre-built binary for arm64. As of October 2020, this is not available in their custom Debian repo, and Bazel does not officially provide an RPM. Instead, we recommend using the [Bazelisk installer](https://docs.bazel.build/versions/master/install-bazelisk.html), which will replace your `bazel` command and [keep bazel up to date](https://github.com/bazelbuild/bazelisk/blob/master/README.md).
 
-Below is an example using the [latest Arm binary release of Bazelisk](https://github.com/bazelbuild/bazelisk/releases/latest) as of August 2020:
+Below is an example using the [latest Arm binary release of Bazelisk](https://github.com/bazelbuild/bazelisk/releases/latest) as of October 2020:
 ```
-wget https://github.com/bazelbuild/bazelisk/releases/download/v1.6.1/bazelisk-linux-arm64
+wget https://github.com/bazelbuild/bazelisk/releases/download/v1.7.1/bazelisk-linux-arm64
 chmod +x bazelisk-linux-arm64
 sudo mv bazelisk-linux-arm64 /usr/local/bin/bazel
 bazel


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Update bazelisk to latest release, confirmed it pulls the latest 3.6.0-linux-arm64 version on Graviton2

```
[ssm-user ~]$ sudo mv bazelisk-linux-arm64 /usr/local/bin/bazel
[ssm-user ~]$ bazel
2020/10/08 17:25:16 Downloading https://releases.bazel.build/3.6.0/release/bazel-3.6.0-linux-arm64...
Extracting Bazel installation...
                                                           [bazel release 3.6.0]
Usage: bazel <command> <options> ...

Available commands:
  analyze-profile     Analyzes build profile data.
  aquery              Analyzes the given targets and queries the action graph.
  build               Builds the specified targets.
  canonicalize-flags  Canonicalizes a list of bazel options.
  clean               Removes output files and optionally stops the server.
  coverage            Generates code coverage report for specified test targets.
  cquery              Loads, analyzes, and queries the specified targets w/ configurations.
  dump                Dumps the internal state of the bazel server process.
  fetch               Fetches external repositories that are prerequisites to the targets.
  help                Prints help for commands, or the index.
  info                Displays runtime info about the bazel server.
  license             Prints the license of this software.
  mobile-install      Installs targets to mobile devices.
  print_action        Prints the command line args for compiling a file.
  query               Executes a dependency graph query.
  run                 Runs the specified target.
  shutdown            Stops the bazel server.
  sync                Syncs all repositories specified in the workspace file
  test                Builds and runs the specified test targets.
  version             Prints version information for bazel.

Getting more help:
  bazel help <command>
                   Prints help and options for <command>.
  bazel help startup_options
                   Options for the JVM hosting bazel.
  bazel help target-syntax
                   Explains the syntax for specifying targets.
  bazel help info-keys
                   Displays a list of keys used by the info command.
[ssm-user ~]$ bazel version
Bazelisk version: v1.7.1
Build label: 3.6.0
Build target: bazel-out/aarch64-opt/bin/src/main/java/com/google/devtools/build/lib/bazel/BazelServer_deploy.jar
Build time: Tue Oct 6 14:31:45 2020 (1601994705)
Build timestamp: 1601994705
Build timestamp as int: 1601994705
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
