### PR TITLE
Move ecs-cli to supported list

### DIFF
--- a/containers-workarounds.md
+++ b/containers-workarounds.md
@@ -10,7 +10,6 @@ We've documented ways to leverage these products below:
 | Name                      | URL / Github issue            | Workaround             | Existing image? |
 | :-----                    |:-----                         | :-----                 | :-----          |
 | FireLens for Amazon ECS | https://github.com/aws/aws-for-fluent-bit/issues/44 | compile from source | |
-| ECS CLI | https://github.com/aws/amazon-ecs-cli/pull/1066 | use PR branch | |
 | cluster-autoscaler | https://github.com/kubernetes/autoscaler/issues/3419 | compile from source or use PR branch | raspbernetes/cluster-autoscaler |
 | external-dns | https://github.com/kubernetes-sigs/external-dns/issues/1443 | compile from source | raspbernetes/external-dns	|
 | kube-state-metrics | https://github.com/kubernetes/kube-state-metrics/issues/1037 | compile from source | alittlec/kube-state-metrics-arm64 |

--- a/containers.md
+++ b/containers.md
@@ -61,6 +61,7 @@ We have compiled a list of popular software within the container ecosystem that 
 |kube-bench | https://github.com/aquasecurity/kube-bench/releases/tag/v0.3.1 ||
 |metrics-server | https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.3.7 | docker image is multi-arch from v.0.3.7 |
 |AWS Copilot | https://github.com/aws/copilot-cli/releases/tag/v0.3.0 | arm64 support as of v0.3.0 |
+|AWS ecs-cli | https://github.com/aws/amazon-ecs-cli/pull/1110 | v1.20.0 binaries in us-west-2 s3 |
 | Amazon EC2 Instance Selector | https://github.com/aws/amazon-ec2-instance-selector/releases/ | also supports the -a cpu_architecture flag for discovering arm64-based instances in a particular region |
 | AWS Node Termination Handler | https://github.com/aws/aws-node-termination-handler/releases/ | arm64 support under kubernetes (via helm) |
 | AWS IAM Authenticator	 | 	https://docs.aws.amazon.com/eks/latest/userguide/install-aws-iam-authenticator.html	 	| | 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
ecs-cli now publishes arm64 binaries as of v1.20.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
