### PR TITLE
Update now Go 1.16 has been released

### DIFF
--- a/golang.md
+++ b/golang.md
@@ -4,10 +4,9 @@ Go is a statically typed, compiled programming language originally designed at G
 
 Here are some noteworthy performance upgrades:
 
-## Go 1.16 \[Coming soon\]
+## Go 1.16 \[released 2021/02/16\]
 The main implementation of the Go compiler, [golang/go](https://github.com/golang/go), has improved
-performance on Arm with couple of changes listed below. It is expected to be released in January 2021. Building your project with Go 1.16
-will give you these improvements:
+performance on Arm with couple of changes listed below. Building your project with Go 1.16 will give you these improvements:
 
  * [ARMv8.1-A Atomics instructions](https://go-review.googlesource.com/c/go/+/234217), which dramatically improve mutex fairness and speed on Graviton 2, and modern Arm core with v8.1 and newer instruction set.
  * [copy performance improvements](https://go-review.googlesource.com/c/go/+/243357), especially when the addresses are unaligned.


### PR DESCRIPTION
Fix references to Go 1.16 as an upcoming release now it has been released (as of 2021/02/16)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
