### PR TITLE
Add X2gd to the readme page

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This repository is meant to help new users start using the Arm-based AWS Gravito
 # Building for Graviton and Graviton2
 The Graviton CPU (powering [A1](https://aws.amazon.com/ec2/instance-types/a1/) instances) supports Arm V8.0 and includes support for CRC and crypto extensions.
 
-The Graviton2 CPU (powering [M6g/M6gd](https://aws.amazon.com/ec2/instance-types/m6/), [C6g/C6gd/C6gn](https://aws.amazon.com/ec2/instance-types/c6/), [R6g/R6gd](https://aws.amazon.com/ec2/instance-types/r6/), and [T4g](https://aws.amazon.com/ec2/instance-types/t4) instances) uses the Neoverse-N1 core and supports Arm V8.2 (include CRC and crypto extensions) plus several
+The Graviton2 CPU (powering [M6g/M6gd](https://aws.amazon.com/ec2/instance-types/m6/), [C6g/C6gd/C6gn](https://aws.amazon.com/ec2/instance-types/c6/), [R6g/R6gd](https://aws.amazon.com/ec2/instance-types/r6/), [T4g](https://aws.amazon.com/ec2/instance-types/t4), and [X2gd](https://aws.amazon.com/ec2/instance-types/x2/) instances) uses the Neoverse-N1 core and supports Arm V8.2 (include CRC and crypto extensions) plus several
 other architectural extensions. In particular, Graviton2 supports the Large
 System Extensions (LSE) which improve locking and synchronization performance
 across large systems. In addition, it has support for fp16 and 8-bit dot


### PR DESCRIPTION
Description of changes: Add newly launched X2gd instance to the readme page with a link to the instance webpage.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
