### PR TITLE
Updated HAProxy build flag in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Package | Version | Improvements
 --------|:-:|-------------
 bazel	| [3.4.1+](https://github.com/bazelbuild/bazel/releases) | Pre-built bazel binary for Graviton/Arm64. [See below](#bazel-on-linux) for installation. 
 ffmpeg  |   4.3+  | Improved performance of libswscale by 50% with better NEON vectorization which improves the performance and scalability of ffmpeg multi-thread encoders. The changes are available in FFMPEG version 4.3.
-HAProxy  | 2.4+  | A [serious bug](https://github.com/haproxy/haproxy/issues/958) was fixed. Additionally, building with `-march=armv8.2-a` improves HAProxy performance by 4x so please rebuild your code with this flag.
+HAProxy  | 2.4+  | A [serious bug](https://github.com/haproxy/haproxy/issues/958) was fixed. Additionally, building with `CPU=armv81` improves HAProxy performance by 4x so please rebuild your code with this flag.
 mongodb | 4.2.13+ / 4.4.5+ / 4.9.0+ | Improved performance on graviton, especially for internal JS engine. Consider compiling from source with an up-to-date compiler to use LSE locks. See [C/C++](c-c++.md) for compiler support.
 MySQL   | 8.0.23+ | Improved spinlock behavior, compiled with -moutline-atomics if compiler supports it.
 .NET | [5+](https://dotnet.microsoft.com/download/dotnet/5.0) | [.NET 5 significantly improved performance for ARM64](https://devblogs.microsoft.com/dotnet/Arm64-performance-in-net-5/). Here's an associated [AWS Blog](https://aws.amazon.com/blogs/compute/powering-net-5-with-aws-graviton2-benchmark-results/) with some performance results. 


### PR DESCRIPTION
*Issue #, if available:*
Updates the expected build flag
*Description of changes:*
https://github.com/haproxy/haproxy/blob/3e6690a55513f2c10dfc7875b9ec2bb5333dee5f/INSTALL#L289

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
