### PR TITLE
Prevent error when no .so file is found

### DIFF
--- a/java.md
+++ b/java.md
@@ -42,7 +42,7 @@ A quick way to check if a JAR contains such shared objects is to simply unzip it
 any of the resulting files are shared-objects and if an aarch64 (arm64) shared-object is missing:
 ```
 $ unzip foo.jar
-$ find . -name "*.so" | xargs file
+$ find . -name "*.so" -exec file {} \;
 ```
 For each x86-64 ELF file, check there is a corresponding aarch64 ELF file
 in the binaries. With some common packages (e.g. commons-crypto) we've seen that


### PR DESCRIPTION
*Description of changes:*
When trying to find native libraries in a .jar file, if no .so file is found and an empty output is sent to "xargs file", it
triggers an error.
Using find .... -exec prevent the error from happening even when no file is found.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
