### PR TITLE
Add Calico/ Update Cilium ARM support 

### DIFF
--- a/containers.md
+++ b/containers.md
@@ -49,7 +49,7 @@ We have compiled a list of popular software within the container ecosystem that 
 |Trivy	 | 	https://github.com/aquasecurity/trivy/releases/	 	 | |
 |Argo	 | 	https://github.com/argoproj/argo/releases/	 	 	 | |
 |Cilium	| https://docs.cilium.io/en/stable/contributing/development/images/ |  Multi arch supported from v 1.10.0 |	 
-|Calico	| https://hub.docker.com/r/calico/node/tags?page=1&ordering=last_updated |  Multi arch supported from v 1.10.0 |	 
+|Calico	| https://hub.docker.com/r/calico/node/tags?page=1&ordering=last_updated |  Multi arch supported on master |	 
 |Tanka	 | 	https://github.com/grafana/tanka/releases	 	 | |
 |Consul	 | 	https://www.consul.io/downloads	 	 | |
 |Nomad	 | 	https://www.nomadproject.io/downloads	| | 	 

--- a/containers.md
+++ b/containers.md
@@ -48,7 +48,8 @@ We have compiled a list of popular software within the container ecosystem that 
 |Cri-o	 | 	https://github.com/cri-o/cri-o/blob/master/README.md#installing-crio | tested on Ubuntu 18.04 and 20.04	|
 |Trivy	 | 	https://github.com/aquasecurity/trivy/releases/	 	 | |
 |Argo	 | 	https://github.com/argoproj/argo/releases/	 	 	 | |
-|Cilium	| https://cilium.io/blog/2020/06/22/cilium-18/#arm64 | initial support |	 
+|Cilium	| https://docs.cilium.io/en/stable/contributing/development/images/ |  Multi arch supported from v 1.10.0 |	 
+|Calico	| https://hub.docker.com/r/calico/node/tags?page=1&ordering=last_updated |  Multi arch supported from v 1.10.0 |	 
 |Tanka	 | 	https://github.com/grafana/tanka/releases	 	 | |
 |Consul	 | 	https://www.consul.io/downloads	 	 | |
 |Nomad	 | 	https://www.nomadproject.io/downloads	| | 	 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Calico and Cilium Multi arch images are available in docker hub and quay.io. Updating container.md to include Calico/Cilium 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
