### PR TITLE
[utilities] update docker cgroup to reflect the correct vcpus

### DIFF
--- a/perfrunbook/utilities/configure_vcpus.sh
+++ b/perfrunbook/utilities/configure_vcpus.sh
@@ -49,3 +49,6 @@ done
 for i in $vcpus_off; do
   echo 0 > /sys/devices/system/cpu/cpu$i/online
 done
+
+# Workaround for online cpus not reflected in docker run
+cp /sys/fs/cgroup/cpuset/cpuset.cpus /sys/fs/cgroup/cpuset/docker/cpuset.cpus


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
workaround to fix the issue with online vcpus not being updated correctly in docker cgroups.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
