### PR TITLE
[utilities] update docker cgroup to reflect the correct vcpus

### DIFF
--- a/perfrunbook/utilities/configure_vcpus.sh
+++ b/perfrunbook/utilities/configure_vcpus.sh
@@ -50,8 +50,9 @@ for i in $vcpus_off; do
   echo 0 > /sys/devices/system/cpu/cpu$i/online
 done
 
-# Workaround for online cpus not reflected in docker run
+# Update Docker cpusets to reflect cpus that are hotplugged in/out to allow
+# restarted containers so they see the proper number of CPUs
 FILE=/sys/fs/cgroup/cpuset/docker/cpuset.cpus
 if [ -f "$FILE" ]; then
-cp /sys/fs/cgroup/cpuset/cpuset.cpus /sys/fs/cgroup/cpuset/docker/cpuset.cpus
+  cp /sys/fs/cgroup/cpuset/cpuset.cpus /sys/fs/cgroup/cpuset/docker/cpuset.cpus
 fi

--- a/perfrunbook/utilities/configure_vcpus.sh
+++ b/perfrunbook/utilities/configure_vcpus.sh
@@ -49,3 +49,9 @@ done
 for i in $vcpus_off; do
   echo 0 > /sys/devices/system/cpu/cpu$i/online
 done
+
+# Workaround for online cpus not reflected in docker run
+FILE=/sys/fs/cgroup/cpuset/docker/cpuset.cpus
+if [ -f "$FILE" ]; then
+cp /sys/fs/cgroup/cpuset/cpuset.cpus /sys/fs/cgroup/cpuset/docker/cpuset.cpus
+fi


### PR DESCRIPTION
*Issue #, if available:*
online CPUs are not being visible to the docker run, hence even if the container is relaunched, it is still not able to utilize the cpus online'd after reboot.
*Description of changes:*
This PR updates the docker cgroup cpuset.cpus to that of the host.  Both running and new container launches have been verified.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
