### PR TITLE
Adding lambda function finder script

### DIFF
--- a/sample-code/lambda_region_finder.sh
+++ b/sample-code/lambda_region_finder.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 # Graviton2 Function Finder
 # Identify Lambda functions with Graviton2 compatiable and not-ompatiable runtimes versions.  Looks in all regions where Graviton2 Lambda is currently available.
@@ -10,27 +10,24 @@ unsupported_runtimes=(python3.6 python3.7 python2.7 nodejs10.x dotnetcore2.1 rub
 
 echo "Graviton2 Function Support Finder"
 
-for region in "${supported_regions[@]}"
-do
-    echo "  "
-    echo "Region: [${region}] - Functions WITH Graviton Compatible Runtimes"
-    echo "  "
+for region in "${supported_regions[@]}"; do
+	echo "  "
+	echo "Region: [${region}] - Functions WITH Graviton Compatible Runtimes"
+	echo "  "
 
-    for runtime in "${supported_runtimes[@]}"
-    do
-            aws lambda list-functions --region ${region} --output text --query "Functions[?Runtime=='${runtime}'].{ARN:FunctionArn, Runtime:Runtime}"
-    
-    # include the container image functions
-    aws lambda list-functions --region ${region} --output text --query "Functions[?PackageType=='Image'].{ARN:FunctionArn, PackageType:'container-image'}"
-    done
-    
-    echo "  "
-    echo "Region: [${region}] - Functions with Runtimes that are NOT Compatible with Graviton2. Require a Runtime version update."
-    echo "  "
+	for runtime in "${supported_runtimes[@]}"; do
+		aws lambda list-functions --region "${region}" --output text --query "Functions[?Runtime=='${runtime}'].{ARN:FunctionArn, Runtime:Runtime}"
 
-    for runtime in "${unsupported_runtimes[@]}"
-    do
-            aws lambda list-functions --region ${region} --output text --query "Functions[?Runtime=='${runtime}'].{ARN:FunctionArn, Runtime:Runtime}"
-    done
+		# include the container image functions
+		aws lambda list-functions --region "${region}" --output text --query "Functions[?PackageType=='Image'].{ARN:FunctionArn, PackageType:'container-image'}"
+	done
+
+	echo "  "
+	echo "Region: [${region}] - Functions with Runtimes that are NOT Compatible with Graviton2. Require a Runtime version update."
+	echo "  "
+
+	for runtime in "${unsupported_runtimes[@]}"; do
+		aws lambda list-functions --region "${region}" --output text --query "Functions[?Runtime=='${runtime}'].{ARN:FunctionArn, Runtime:Runtime}"
+	done
 done
 echo "finished"


### PR DESCRIPTION

Adding a Lambda Function finder script to identify functions that have run-times and in regions that are supported by Graviton2. The script also lists functions that are on non-compatible run-times and need a run-time upgrade. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.