### PR TITLE
Update AL2's Clang/LLVM versions

### DIFF
--- a/c-c++.md
+++ b/c-c++.md
@@ -28,7 +28,7 @@ Starred version marks the default system compiler.
 
 Distribution    | GCC                  | Clang/LLVM
 ----------------|----------------------|-------------
-Amazon Linux 2  | 7*, 10               | 7
+Amazon Linux 2  | 7*, 10               | 7, 11*
 Ubuntu 20.04    | 7, 8, 9*, 10         | 6, 7, 8, 9, 10, 11
 Ubuntu 18.04    | 4.8, 5, 6, 7*, 8     | 3.9, 4, 5, 6, 7, 8, 9, 10
 Debian10        | 7, 8*                | 6, 7, 8


### PR DESCRIPTION
AL2 provides Clang/LLVM 7&11 and the default version is 11.

I've updated the table accordingly.

```
$ yum list llvm*
Loaded plugins: extras_suggestions, langpacks, priorities, update-motd
Installed Packages
llvm-libs.aarch64                                     11.1.0-1.amzn2.0.2                             @amzn2-core                                  @amzn2-core
Available Packages                                                                                                                                @amzn2-core
llvm.aarch64                                          11.1.0-1.amzn2.0.2                             amzn2-core                                   @amzn2-core
llvm-devel.aarch64                                    11.1.0-1.amzn2.0.2                             amzn2-core                                   @amzn2-core
llvm-doc.noarch                                       11.1.0-1.amzn2.0.2                             amzn2-core                                   @amzn2-core
llvm-googletest.aarch64                               11.1.0-1.amzn2.0.2                             amzn2-core                                   @amzn2-core
llvm-private.aarch64                                  6.0.1-2.amzn2                                  amzn2-core
llvm-private-devel.aarch64                            6.0.1-2.amzn2                                  amzn2-core                                   amzn2-core
llvm-static.aarch64                                   11.1.0-1.amzn2.0.2                             amzn2-core                                   amzn2-core
llvm-test.aarch64                                     11.1.0-1.amzn2.0.2                             amzn2-core                                   amzn2-core
llvm7.0.aarch64                                       7.0.1-1.amzn2.0.3                              amzn2-core                                   amzn2-core
llvm7.0-devel.aarch64                                 7.0.1-1.amzn2.0.3                              amzn2-core                                   amzn2-core
llvm7.0-doc.noarch                                    7.0.1-1.amzn2.0.3                              amzn2-core                                   amzn2-core
llvm7.0-libs.aarch64                                  7.0.1-1.amzn2.0.3                              amzn2-core                                   amzn2-core
llvm7.0-static.aarch64                                7.0.1-1.amzn2.0.3                              amzn2-core
```

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
