### PR TITLE
[ML inference]: Add tensorflow DLAMI and container details

### DIFF
--- a/containers.md
+++ b/containers.md
@@ -31,6 +31,8 @@ We have compiled a list of popular software within the container ecosystem that 
 | :-----                    |:-----                         | :-----                 |
 | Istio	| https://github.com/istio/istio/releases/	| 1) arm64 binaries as of 1.6.x release series<br>2) [Istio container build instructions](https://github.com/aws/aws-graviton-getting-started/blob/main/containers-workarounds.md#Istio)|
 | Envoy	| https://www.envoyproxy.io/docs/envoy/v1.18.3/start/docker ||
+| Tensorflow | https://hub.docker.com/r/armswdev/tensorflow-arm-neoverse-n1 | tag: r21.12-tf-2.7.0-onednn-acl |
+| Tensorflow serving | 763104351884.dkr.ecr.us-west-2.amazonaws.com/tensorflow-inference-graviton:2.7.0-cpu-py38-ubuntu20.04-e3-v1.0 ||
 | Traefik | https://github.com/containous/traefik/releases	|| 	 
 | Flannel | https://github.com/coreos/flannel/releases	 ||	 
 | Helm | https://github.com/helm/helm/releases/tag/v2.16.9 || 

--- a/tensorflow.md
+++ b/tensorflow.md
@@ -1,32 +1,83 @@
-# Building TensorFlow on Graviton2
+# ML inference on Graviton CPUs with TensorFlow
 
-Install bazel build system:
-```
-# find the latest release of bazel for arm64 https://github.com/bazelbuild/bazel/releases/latest
-# using older bazel versions may not be supported to build tensorflow
-REL=4.2.1  # this is the latest stable release as of this writing
-wget https://github.com/bazelbuild/bazel/releases/download/${REL}/bazel-${REL}-linux-arm64
-chmod +x bazel-${REL}-linux-arm64
-sudo mv bazel-${REL}-linux-arm64 /usr/local/bin
-sudo ln -s /usr/local/bin/bazel-${REL}-linux-arm64 /usr/local/bin/bazel
-```
+There are two ways to use tensforflow based ml inferencing on Graviton CPUs.
+- Tensorflow DLAMI
+- Tensorflow Docker container
 
-Build TensorFlow on Graviton2 with Ubuntu 20.04:
+**Using AWS DLAMI:**
+To launch a Graviton instance with a DLAMI via EC2 console:
+
+1. Click on "Community AMIs"
+2. Filter AMIs by clicking Ubuntu and Arm (64-bit) check boxes
+3. Search for "Deep Learning" in search field to list the current Ubuntu based DLAMIs"
+4. Select the AMI: "Deep Learning AMI Graviton Tensorflow <version>(Ubuntu 20.04) <yyyy/mm/dd>"
+
+Here is the awscli snippet to find the latest AMI:
 ```
-sudo apt install build-essential python python3-pip
-sudo pip3 install numpy keras_preprocessing
-git clone https://github.com/tensorflow/tensorflow $HOME/tensorflow
-cd $HOME/tensorflow
-./configure
-bazel build --config=opt --copt=-O3 --copt=-march=armv8.2-a+fp16+rcpc+dotprod+crypto --copt=-flax-vector-conversions //tensorflow/tools/pip_package:build_pip_package
+aws ec2 describe-images --region us-west-2 --filters  Name=architecture,Values=arm64 Name=name,Values="*Deep Learning AMI*" Name=owner-alias,Values=amazon  --query 'Images[] | sort_by(@, &CreationDate)[-1] | ImageId'
 ```
 
-Run an inference task:
+Here is the awscli snippet to launch the same:
 ```
-cd $HOME/tensorflow/tensorflow/examples/label_image/data
-wget https://storage.googleapis.com/download.tensorflow.org/models/inception_v3_2016_08_28_frozen.pb.tar.gz
-tar xf inception_v3_2016_08_28_frozen.pb.tar.gz
-cd $HOME/tensorflow
-bazel build --config=opt --copt=-O3 --copt=-march=armv8.2-a+fp16+rcpc+dotprod+crypto --copt=-flax-vector-conversions tensorflow/examples/label_image/...
-bazel-bin/tensorflow/examples/label_image/label_image
+aws ec2 run-instances --region us-west-2 --image-id <ami-id from the above command>  --instance-type c6g.4xlarge --count 1  --key-name <key name> --subnet-id <subnet_id> --block-device-mappings 'DeviceName=/dev/sda1,Ebs={VolumeSize=256}'
+```
+
+Once Graviton instance is launched with the above DLAMI, the platform is ready for building Tensorflow based ML inference applications.The DLAMI comes with the additional libraries preinstalled, eg: rust compilers, transformers etc, to enable transformers based (eg: bert) inferencing applications.
+```
+# One can check the TF version as below
+pip show tensorflow
+
+# By default it's eigen, but typically onednn+acl provides better performance and this can be enabled by setting the below TF environment variable
+export TF_ENABLE_OENDNN_OPTS=1
+
+# Graviton3 (eg: c7g instances) supports BF16 format for ML acceleration. This can be enabled in oneDNN by setting the below environment variable
+export DNNL_DEFAULT_FPMATH_MODE=BF16
+```
+
+**Using docker container:**
+Launch a Graviton instance with an Ubuntu 20.04 AMI and instal docker using the below instructions.
+```
+#install and enable docker
+sudo apt update
+sudo apt install -y docker.io
+sudo systemctl enable docker
+sudo systemctl start docker
+sudo usermod -a -G docker ubuntu
+
+# pull the tensorflow docker container with onednn-acl optimizations enabled
+docker pull armswdev/tensorflow-arm-neoverse-n1:r21.11-tf-2.7.0-onednn-acl
+
+# launch the docker image
+docker run -it --rm -v /home/ubuntu/:/hostfs armswdev/tensorflow-arm-neoverse-n1:r21.11-tf-2.7.0-onednn-acl
+
+# Graviton3 (eg: c7g instances) supports BF16 format for ML acceleration. This can be enabled in oneDNN by setting the below environment variable
+export DNNL_DEFAULT_FPMATH_MODE=BF16
+```
+
+**Execute MLPerf inference benchmarks within docker container**
+```
+# The docker image comes pre-installed with the MLPerf inference benchmarks so one can benchmark the install and verify everything is configured properly.
+
+cd examples/MLCommons
+
+# To benchmark mlperf resnet50, image classification model, download the imagenet dataset, select option#1 when prompted
+./download-dataset.sh
+./download-model.sh
+
+cd /home/ubuntu/examples/MLCommons/inference/vision/classification_and_detection
+
+#set the data and model path
+export DATA_DIR=/home/ubuntu/CK-TOOLS/dataset-imagenet-ilsvrc2012-val-min
+export MODEL_DIR=/home/ubuntu/examples/MLCommons/inference/vision/classification_and_detection
+
+# setup the tensorflow thread pool parameters for optimal performance
+export MLPERF_NUM_INTER_THREADS=1
+export MLPERF_NUM_INTRA_THREADS= <#of vcpus>
+
+./run_local.sh tf resnet50 cpu --scenario=Offline
+
+# To benchmark mlperf bert, natural language processing model:
+cd /home/ubuntu/examples/MLCommons/inference/language/bert
+make setup
+python3 run.py --backend=tf --scenario=Offline
 ```


### PR DESCRIPTION
This patch updates the tensorflow section with the latest status
and instructions to get TF based ML inference working on Graviton CPUs.
Also updated the supported containers list with the latest TF containers.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
