### PR TITLE
doc: update jaeger status in containers doc

### DIFF
--- a/containers.md
+++ b/containers.md
@@ -34,7 +34,7 @@ We have compiled a list of popular software within the container ecosystem that 
 | Traefik | https://github.com/containous/traefik/releases	|| 	 
 | Flannel | https://github.com/coreos/flannel/releases	 ||	 
 | Helm | https://github.com/helm/helm/releases/tag/v2.16.9 || 
-| Jaeger | https://github.com/jaegertracing/jaeger/pull/2176 | [dockerhub images are not yet multiarch](https://github.com/jaegertracing/jaeger/issues/2292)	| 
+| Jaeger | https://github.com/jaegertracing/jaeger/pull/2176 | | 
 | Fluent-bit |https://github.com/fluent/fluent-bit/releases/ | compile from source |
 | core-dns |https://github.com/coredns/coredns/releases/ | | 
 | external-dns | https://github.com/kubernetes-sigs/external-dns/blob/master/docs/faq.md#which-architectures-are-supported | support from 0.7.5+ |


### PR DESCRIPTION
*Description of changes:*
Jaeger is already set with the multi-arch build since this [pull request](https://github.com/jaegertracing/jaeger/pull/3124).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
