### PR TITLE
perfrunbook/utilities: Improve capture_flamegraphs.sh script

### DIFF
--- a/perfrunbook/utilities/capture_flamegraphs.sh
+++ b/perfrunbook/utilities/capture_flamegraphs.sh
@@ -2,27 +2,43 @@
 
 set -e
 
+let capture_freq=99
+
+# search replace filter that will combine thread names like 
+# GC-Thread-1 to GC-Thread- in perf-script sample header lines.
+sr_filter='s/^([a-zA-Z\-]+)[0-9]*-?([a-zA-z]*) (.*?)$/\1\2 \3/g'
+
 help_msg() {
  echo "Requires perf to be installed and in your PATH"
- echo "usage: $0 oncpu|offcpu [time seconds|default 300]"
+ echo "usage: $0 oncpu|offcpu|<custom_event> [time seconds|default 300] --f|--frequency 99 -r|--regexfilter 's/hi/bye/g'"
+ echo "custom_event is any event listed in perf-list"
+}
+
+process_perf_data () {
+  perf inject -j -i perf.data -o perf.data.jit
+  perf script -f -i perf.data.jit > script.out
+  
+  if [[ ! -z "${sr_filter}" ]]; then
+    perl -pi -e "${sr_filter}" script.out
+  fi
+  ./FlameGraph/stackcollapse-perf.pl --kernel --jit script.out > folded.out
+  ./FlameGraph/flamegraph.pl --colors java folded.out > flamegraph_$1_$4_$3_$2.svg
+  rm perf.data perf.data.jit script.out folded.out
 }
 
 capture_on_cpu () {
-  perf record -a -g -k 1 -F99 -e cpu-clock:pppH -- sleep $1
-  perf inject -j -i perf.data -o perf.data.jit
-  perf script -f -i perf.data.jit > script.out
-  ./FlameGraph/stackcollapse-perf.pl --kernel --jit script.out > folded.out
-  ./FlameGraph/flamegraph.pl --colors java folded.out > flamegraph_oncpu_$4_$3_$2.svg
-  rm perf.data perf.data.jit script.out folded.out
+  perf record -a -g -k 1 -F${capture_freq} -e cpu-clock:pppH -- sleep $1
+  process_perf_data "oncpu" $2 $3 $4
 }
 
 capture_off_cpu () {
-  perf record -a -g -k 1 -F99 -e sched:sched_switch -- sleep $1
-  perf inject -j -i perf.data -o perf.data.jit
-  perf script -f -i perf.data.jit > script.out
-  ./FlameGraph/stackcollapse-perf.pl --kernel --jit script.out > folded.out
-  ./FlameGraph/flamegraph.pl --colors java folded.out > flamegraph_offcpu_$4_$3_$2.svg
-  rm perf.data perf.data.jit script.out folded.out
+  perf record -a -g -k 1 -F${capture_freq} -e sched:sched_switch -- sleep $1
+  process_perf_data "offcpu" $2 $3 $4
+}
+
+capture_custom_event () {
+  perf record -a -g -k 1 -F${capture_freq} -e $1 -- sleep $2
+  process_perf_data $1 $3 $4 $5
 }
 
 if [[ $(id -u) -ne 0 ]]; then
@@ -53,11 +69,31 @@ if [[ $? -ne 0 ]]; then
   exit 1
 fi
 
+POSITIONAL=()
+while [[ $# -gt 0 ]]
+do
+  key="$1"
+  case $key in
+    -f|--frequency)
+      let capture_freq="$2"
+      shift; shift
+      ;;
+    -r|--regexfilter)
+      sr_filter="$2"
+      shift; shift
+      ;;
+    *)
+      POSITIONAL+=("$1")
+      shift
+      ;;
+  esac
+done
+set -- "${POSITIONAL[@]}"
+
 if [[ "$1" == "oncpu" ]]; then
   capture_on_cpu $capture_time $date $instance_type $instance_id
 elif [[ "$1" == "offcpu" ]]; then
   capture_off_cpu $capture_time $date $instance_type $instance_id
 else
-  help_msg
-  exit 1
+  capture_custom_event $1 $capture_time $date $instance_type $instance_id
 fi


### PR DESCRIPTION
Add tunable event capture frequency for oncpu and other perf-counter
events with the -f|--frequency flag. Add a tunable regex to filter perf-script output
with the -r|--regexfilter flag, the default behavior is to filter thread
names and combine stack traces from the same base name, i.e. GC-Thread-N
will show up as GC-Thread- instead of multiple traces for each
individual.  Add ability to define a custom perf event to capture on
instead of just oncpu|offcpu, can now specify any event that can be
passed to the -e flag in perf.

Ex: To capture traces of what code queues IO to block devices: `sudo ./capture_flamegraphs.sh block:block_bio_queue 60`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
