### PR TITLE
Add link to Docker blog for native buildx

### DIFF
--- a/containers.md
+++ b/containers.md
@@ -113,6 +113,7 @@ If using the Kubernetes [Cluster Autoscaler](https://github.com/kubernetes/autos
 
 ### Further reading
 
+* [Speed up Docker BuildX by building natively on EC2 Graviton](https://www.docker.com/blog/speed-up-building-with-docker-buildx-and-graviton2-ec2/)
 * [Building multi-arch docker images with buildx](https://tech.smartling.com/building-multi-architecture-docker-images-on-arm-64-c3e6f8d78e1c)
 * [Unifying Arm software development with Docker](https://community.arm.com/developer/tools-software/tools/b/tools-software-ides-blog/posts/unifying-arm-software-development-with-docker)
 * [Modern multi-arch builds with docker](https://duske.me/posts/modern-multiarch-builds-with-docker/)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Docker published a blog about speeding up docker buildx using EC2 Graviton instead of emulation. Add a link to that informative blog post.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
