### PR TITLE
[perfrunbook/utilities] fix parse error

### DIFF
--- a/perfrunbook/utilities/measure_and_plot_basic_pmu_counters.py
+++ b/perfrunbook/utilities/measure_and_plot_basic_pmu_counters.py
@@ -75,7 +75,7 @@ def plot_counter_stat(csv, plot_format, stat_name, counter_numerator,
     Process the returned csv file into a time-series statistic to plot and
     also calculate some useful aggregate stats.
     """
-    df = pd.read_csv(csv, sep='|', header=0,
+    df = pd.read_csv(csv, sep='|',
                      names=['time', 'count', 'rsrvd1', 'event',
                             'rsrvd2', 'frac', 'rsrvd3', 'rsrvd4'],
                      dtype={'time': np.float64, 'count': np.float64,


### PR DESCRIPTION
running the perfbook tool used to fail like this:
```
$ ~/aws-graviton-getting-started/perfrunbook/utilities/measure_and_plot_basic_pmu_counters.py --stat stall_backend_pkc --plot terminal --time 1
[...]
TypeError: unsupported operand type(s) for -: 'NoneType' and 'NoneType'
```
That was due to the first line in the csv file being truncated.
The patch fixes this issue. 