### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ If you are new to Graviton and want to understand how to identify target workloa
 # Optimizing for Graviton
 Please refer [here](optimizing.md) for general debugging and profiling information.  For detailed checklists on optimizing and debugging performance on Graviton, see our [performance runbook](perfrunbook/graviton_perfrunbook.md).
 
-Different architectures and systems have differing capabilities, which means some tools you might be familiar with on one architecture don't have equivalent on AWS Graviton. Documented [here](https://github.com/RamaMalladiAWS/aws-graviton-getting-started/blob/main/Monitoring_Tools_on_Graviton.md) are some of these utilities.
+Different architectures and systems have differing capabilities, which means some tools you might be familiar with on one architecture don't have equivalent on AWS Graviton. Documented [here](Monitoring_Tools_on_Graviton.md) are some of these utilities.
 
 # Recent software updates relevant to Graviton
 There is a huge amount of activity in the Arm software ecosystem and improvements are being


### PR DESCRIPTION
https://github.com/aws/aws-graviton-getting-started/pull/233 linked to a forked copy of the Monitoring page, instead of the one in this repo. Fix it.

*Issue #, if available:* Fixes #233

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
