### PR TITLE
Update Java section about libperf-jvmti.so support from perf in Linux

### DIFF
--- a/CommonNativeJarsTable.md
+++ b/CommonNativeJarsTable.md
@@ -12,8 +12,8 @@ io.netty | [netty-transport-native-epoll](https://github.com/netty/netty) | yes 
 io.netty | [netty-tcnative](https://github.com/netty/netty-tcnative) | yes | [yes](https://mvnrepository.com/artifact/io.netty/netty-tcnative) | 2.0.31
 org.fusesource.jansi | [jansi-native](https://github.com/fusesource/jansi-native) | yes | no |
 org.fusesource.leveldbjni | [leveldbjni-all](https://github.com/fusesource/leveldbjni) | no | no |
-org.fusesource.sigar | [sigar](https://github.com/hyperic/sigar) | yes (refer https://github.com/hyperic/sigar/pull/140) | no |
+org.fusesource.sigar | [sigar](https://github.com/hyperic/sigar) | yes (refer https://github.com/hyperic/sigar/pull/140) | [debian](https://pkgs.org/download/libhyperic-sigar-java) | 1.6.4
 org.apache.hadoop | [hadoop-lzo](https://github.com/twitter/hadoop-lzo) | yes | no |
 
 ---
-Updated on 2020-06-16
+Updated on 2022-08-02

--- a/java.md
+++ b/java.md
@@ -159,7 +159,7 @@ $ perf script -i perf.data.jit | ./FlameGraph/stackcollapse-perf.pl | ./FlameGra
 ```
 
 ### Build libperf-jvmti.so on Amazon Linux 2
-Amazon Linux 2 does not package `libperf-jvmti.so` by default with the `perf` yum package.  
+Amazon Linux 2 does not package `libperf-jvmti.so` by default with the `perf` yum package for kernel versions <5.10.
 Build the `libperf-jvmti.so` shared library using the following steps:
 
 ```bash

--- a/python.md
+++ b/python.md
@@ -4,7 +4,13 @@ Python is an interpreted, high-level, general-purpose programming language, with
 
 ## 1. Installing Python packages
 
-When *pip* (the standard package installer for Python) is used, it pulls the packages from [Python Package Index](https://pypi.org) and other indexes.
+When *pip* (the standard package installer for Python) is used, it pulls the packages from [Python Package Index](https://pypi.org) and other indexes. To ensure you
+can install binary packages from [Python Package Index](https://pypi.org), make sure to update your pip installation to a new enough version \(>19.3\).
+
+```
+# To ensure an up-to-date pip version
+sudo python3 -m pip install --upgrade pip
+```
 
 AWS is actively working to make pre-compiled packages available for Graviton. You can see a current list of the over 200 popular python packages we track nightly
 for AL2 and Ubuntu for Graviton support status at our [Python wheel tester](https://geoffreyblake.github.io/arm64-python-wheel-tester/).  


### PR DESCRIPTION
5.10, update supported native jars, and update python
work-arounds for installing pip packages in the python.md section.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
