### PR TITLE
Add details / link to Istio multi-arch images

### DIFF
--- a/containers.md
+++ b/containers.md
@@ -29,7 +29,7 @@ We have compiled a list of popular software within the container ecosystem that 
 
 | Name                      | URL                           | Comment                |
 | :-----                    |:-----                         | :-----                 |
-| Istio	| https://github.com/istio/istio/releases/	| 1) [Arm64 support is now available via the master branch](https://github.com/istio/istio/issues/26652). To try it out follow: https://github.com/istio/istio/wiki/Dev-Builds#dev-release-information. Support will be included in the upcoming 1.15 release ETA ~1 month.<br> Multi-arch images starting to appear [here](https://hub.docker.com/r/istio/proxyv2/tags) with 1.15.0-beta releases.<br> 2) [Istio container build instructions](https://github.com/aws/aws-graviton-getting-started/blob/main/containers-workarounds.md#Istio)|
+| Istio	| https://github.com/istio/istio/releases/	| 1) [Arm64 support is now available via the master branch](https://github.com/istio/istio/issues/26652). To try it out follow: https://github.com/istio/istio/wiki/Dev-Builds#dev-release-information. Support will be included in the upcoming 1.15 release ETA Sept/Oct'22.<br> 1.15.0 multi-arch Beta images are now available [here](https://hub.docker.com/r/istio/proxyv2/tags) with 1.15.0-beta releases.<br> 2) [Istio container build instructions](https://github.com/aws/aws-graviton-getting-started/blob/main/containers-workarounds.md#Istio)|
 | Envoy	| https://www.envoyproxy.io/docs/envoy/v1.18.3/start/docker ||
 | Tensorflow | https://hub.docker.com/r/armswdev/tensorflow-arm-neoverse |  |
 | Tensorflow serving | 763104351884.dkr.ecr.us-west-2.amazonaws.com/tensorflow-inference-graviton:2.7.0-cpu-py38-ubuntu20.04-e3-v1.0 ||

--- a/containers.md
+++ b/containers.md
@@ -29,7 +29,7 @@ We have compiled a list of popular software within the container ecosystem that 
 
 | Name                      | URL                           | Comment                |
 | :-----                    |:-----                         | :-----                 |
-| Istio	| https://github.com/istio/istio/releases/	| 1) [Arm64 support is now available via the master branch](https://github.com/istio/istio/issues/26652). To try it out follow: https://github.com/istio/istio/wiki/Dev-Builds#dev-release-information. Support will be included in the upcoming 1.15 release ETA ~1 month.<br>2) [Istio container build instructions](https://github.com/aws/aws-graviton-getting-started/blob/main/containers-workarounds.md#Istio)|
+| Istio	| https://github.com/istio/istio/releases/	| 1) [Arm64 support is now available via the master branch](https://github.com/istio/istio/issues/26652). To try it out follow: https://github.com/istio/istio/wiki/Dev-Builds#dev-release-information. Support will be included in the upcoming 1.15 release ETA ~1 month.<br> Multi-arch images starting to appear [here](https://hub.docker.com/r/istio/proxyv2/tags) with 1.15.0-beta releases.<br> 2) [Istio container build instructions](https://github.com/aws/aws-graviton-getting-started/blob/main/containers-workarounds.md#Istio)|
 | Envoy	| https://www.envoyproxy.io/docs/envoy/v1.18.3/start/docker ||
 | Tensorflow | https://hub.docker.com/r/armswdev/tensorflow-arm-neoverse |  |
 | Tensorflow serving | 763104351884.dkr.ecr.us-west-2.amazonaws.com/tensorflow-inference-graviton:2.7.0-cpu-py38-ubuntu20.04-e3-v1.0 ||


### PR DESCRIPTION
As of v1.15.0-beta the multi-arch Istio images are starting to show up in the Docker Hub repo here: https://hub.docker.com/r/istio/proxyv2/tags - adding this deatil to the getting started guide.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
