### PR TITLE
Add reference to Porting Advisor for Graviton

### DIFF
--- a/transition-guide.md
+++ b/transition-guide.md
@@ -40,6 +40,7 @@ Before starting the transition, you will need to inventory your current software
 * All the libraries, frameworks and runtimes used by the application.
 * Tools used to build, deploy and test your application (e.g. compilers, test suites, CI/CD pipelines, provisioning tools and scripts). Note there are language specific sections in the getting started guide with useful pointers to getting the best performance from Graviton processors.
 * Tools and/or agents used to deploy and manage the application in production (e.g. monitoring tools or security agents)
+* The [Porting Advisor for Graviton](https://github.com/aws/porting-advisor-for-graviton) is an open-source command line tool that analyzes source code and generates a report highlighting missing and outdated libraries and code constructs that may require modification along with recommendations for alternatives. It accelerates your transition to AWS Graviton-based instances by reducing the iterative process of identifying and resolving source code and library dependencies
 * This guide contains language specifics sections where you'll find additional per-language guidance:
   * [C/C++](c-c++.md)
   * [Go](golang.md)


### PR DESCRIPTION
Update Step 2 to include additional bullet referencing the newly released Porting Advisor for Graviton to help scan source trees.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
