### PR TITLE
Check for __ARM_NEON instead of __ARM_NEON__

### DIFF
--- a/SIMD_and_vectorization.md
+++ b/SIMD_and_vectorization.md
@@ -96,7 +96,7 @@ The instructions are defined in *arm_neon.h*.
 A portable code that would detect (at compile-time) an Arm CPU and compiler would look like:
 
 ```
-#if (defined(__clang__) || (defined(__GCC__)) && (defined(__ARM_NEON__) || defined(__aarch64__))
+#if (defined(__clang__) || (defined(__GCC__)) && (defined(__ARM_NEON) || defined(__aarch64__))
 /* compatible compiler, targeting arm neon */
 #include <arm_neon.h>
 #include <arm_acle.h>


### PR DESCRIPTION
With recent `clang` and `gcc`, only `__ARM_NEON` gets defined - but not `__ARM_NEON__`:

```
$ clang --version
clang version 17.0.0 (https://github.com/llvm/llvm-project.git b688b58f83ceb48dbe185be95372e45de1d51401)
Target: aarch64-unknown-linux-gnu
Thread model: posix
InstalledDir: /usr/bin

$ clang -dM -E -x c -mcpu=neoverse-n1 /dev/null | grep ARM_NEON
#define __ARM_NEON 1
#define __ARM_NEON_FP 0xE

$ gcc10-gcc --version
gcc10-gcc (GCC) 10.4.1 20221124 (Red Hat 10.4.0-1)
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

$ gcc10-gcc -dM -E -x c -mcpu=neoverse-n1 /dev/null | grep ARM_NEON
#define __ARM_NEON 1
```

The correct check is implemented in [AWS libcrypto](https://github.com/aws/aws-lc/blob/0b3b55b049a74bf1ddb871dbef6db24caa656cb8/crypto/fipsmodule/cpucap/internal.h#LL130-L132), for example.