### PR TITLE
Amazon Linux 2023 added to install_perfrunbook_dependencies

### DIFF
--- a/perfrunbook/utilities/install_perfrunbook_dependencies.sh
+++ b/perfrunbook/utilities/install_perfrunbook_dependencies.sh
@@ -2,16 +2,16 @@
 
 install_al2023_dependencies () {
   echo "------ INSTALLING UTILITIES ------"
-  yum install -y -q vim unzip git
+  dnf install -y -q vim unzip git
 
   echo "------ INSTALLING HIGH LEVEL PERFORMANCE TOOLS ------"
-  yum install -y -q sysstat htop hwloc tcpdump
+  dnf install -y -q sysstat htop hwloc tcpdump
 
   echo "------ INSTALLING LOW LEVEL PERFORAMANCE TOOLS ------"
-  yum install -y -q perf kernel-devel-$(uname -r) bcc
+  dnf install -y -q perf kernel-devel-$(uname -r) bcc
 
   echo "------ INSTALL ANALYSIS TOOLS AND DEPENDENCIES ------"
-  yum install -y -q python3 python3-pip
+  dnf install -y -q python3 python3-pip
   python3 -m pip install --upgrade pip
   python3 -m pip install pandas numpy scipy matplotlib sh seaborn plotext
   git clone https://github.com/brendangregg/FlameGraph.git FlameGraph

--- a/perfrunbook/utilities/install_perfrunbook_dependencies.sh
+++ b/perfrunbook/utilities/install_perfrunbook_dependencies.sh
@@ -1,5 +1,23 @@
 #!/bin/bash
 
+install_al2023_dependencies () {
+  echo "------ INSTALLING UTILITIES ------"
+  yum install -y -q vim unzip git
+
+  echo "------ INSTALLING HIGH LEVEL PERFORMANCE TOOLS ------"
+  yum install -y -q sysstat htop hwloc tcpdump
+
+  echo "------ INSTALLING LOW LEVEL PERFORAMANCE TOOLS ------"
+  yum install -y -q perf kernel-devel-$(uname -r) bcc
+
+  echo "------ INSTALL ANALYSIS TOOLS AND DEPENDENCIES ------"
+  yum install -y -q python3 python3-pip
+  python3 -m pip install --upgrade pip
+  python3 -m pip install pandas numpy scipy matplotlib sh seaborn plotext
+  git clone https://github.com/brendangregg/FlameGraph.git FlameGraph
+
+  echo "------ DONE ------"
+}
 install_al2_dependencies () {
   echo "------ INSTALLING UTILITIES ------"
   yum install -y -q vim unzip git
@@ -49,7 +67,9 @@ fi
 os_name=$(cat /etc/os-release | grep "PRETTY_NAME" | awk -F"=" '{print $2}' | tr -d '[="=]' | tr -d [:cntrl:])
 
 
-if [[ "$os_name" == "Amazon Linux 2" ]]; then
+if [[ "$os_name" == "Amazon Linux 2023" ]]; then
+  install_al2023_dependencies
+elif [[ "$os_name" == "Amazon Linux 2" ]]; then
   install_al2_dependencies
 elif [[ "$os_name" =~ "Ubuntu 20.04" ]]; then
   install_ubuntu2004_dependencies


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
adding Amazon Linux 2023 if clause to install_perfrunbook_dependencies.sh and removing install for dstat and amazon-linux-extras

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
