### PR TITLE
Update "Recent software updates" table

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,17 +63,20 @@ Different architectures and systems have differing capabilities, which means som
 
 # Recent software updates relevant to Graviton
 There is a huge amount of activity in the Arm software ecosystem and improvements are being
-made on a daily basis. As a general rule later versions of compilers and language runtimes
+made on a daily basis. As a general rule later versions of compilers, language runtimes, and applications
 should be used whenever possible. The table below includes known recent changes to popular
 packages that improve performance (if you know of others please let us know).
 
 Package | Version | Improvements
 --------|:-:|-------------
-bazel	| [3.4.1+](https://github.com/bazelbuild/bazel/releases) | Pre-built bazel binary for Graviton/Arm64. [See below](#bazel-on-linux) for installation. 
+bazel	| [3.4.1+](https://github.com/bazelbuild/bazel/releases) | Pre-built bazel binary for Graviton/Arm64. [See below](#bazel-on-linux) for installation.
+Cassandra | 4.0+ | Supports running on Java/Corretto 11, improving overall performance
 FFmpeg  |   5.1+  | Improved performance of libswscale by 50% with better NEON vectorization which improves the performance and scalability of FFmpeg multi-thread encoders. The changes are available in FFmpeg version 4.3, with further improvements to scaling and motion estimation available in 5.1. Additional improvements to both will be available in 5.2, which has not yet been released as of November 2022. For more information about FFmpeg on Graviton, read the blog post on AWS Open Source Blog, [Optimized Video Encoding with FFmpeg on AWS Graviton Processors](https://aws.amazon.com/blogs/opensource/optimized-video-encoding-with-ffmpeg-on-aws-graviton-processors/).
 HAProxy  | 2.4+  | A [serious bug](https://github.com/haproxy/haproxy/issues/958) was fixed. Additionally, building with `CPU=armv81` improves HAProxy performance by 4x so please rebuild your code with this flag.
+MariaDB | 10.4.14+ | Default build now uses -moutline-atomics, general correctness bugs for Graviton fixed.
 mongodb | 4.2.15+ / 4.4.7+ / 5.0.0+ | Improved performance on graviton, especially for internal JS engine. LSE support added in [SERVER-56347](https://jira.mongodb.org/browse/SERVER-56347).
 MySQL   | 8.0.23+ | Improved spinlock behavior, compiled with -moutline-atomics if compiler supports it.
+PostgreSQL | 15+ | General scalability improvements plus additional [improvements to spin-locks specifically for Arm64](https://commitfest.postgresql.org/37/3527/)
 .NET | [5+](https://dotnet.microsoft.com/download/dotnet/5.0) | [.NET 5 significantly improved performance for ARM64](https://devblogs.microsoft.com/dotnet/Arm64-performance-in-net-5/). Here's an associated [AWS Blog](https://aws.amazon.com/blogs/compute/powering-net-5-with-aws-graviton2-benchmark-results/) with some performance results. 
 OpenH264 | [2.1.1+](https://github.com/cisco/openh264/releases/tag/v2.1.1) | Pre-built Cisco OpenH264 binary for Graviton/Arm64. 
 PCRE2   | 10.34+  | Added NEON vectorization to PCRE's JIT to match first and pairs of characters. This may improve performance of matching by up to 8x. This fixed version of the library now is shipping with Ubuntu 20.04 and PHP 8.
@@ -81,6 +84,7 @@ PHP     | 7.4+    | PHP 7.4 includes a number of performance improvements that i
 pip     | 19.3+   | Enable installation of python wheel binaries on Graviton
 PyTorch | 2.0+    | Optimize Inference latency and throughput on Graviton. [AWS DLCs and python wheels are available](machinelearning/pytorch.md).
 ruby    | 3.0+ | Enable arm64 optimizations that improve performance by as much as 40%. These changes have also been back-ported to the Ruby shipping with AmazonLinux2, Fedora, and Ubuntu 20.04.
+Spark | 3.0+ | Supports running on Java/Corretto 11, improving overall performance.
 zlib    | 1.2.8+  | For the best performance on Graviton please use [zlib-cloudflare](https://github.com/cloudflare/zlib).
 
 # Containers on Graviton


### PR DESCRIPTION
Update the table with versions that customers have asked for guidance on, and packages known to have improved performance on Graviton: Cassandra, MariaDB, Postgresql, Spark