### PR TITLE
Update 2a-install-openmpi-with-acfl.sh

### DIFF
--- a/HPC/scripts-setup/2a-install-openmpi-with-acfl.sh
+++ b/HPC/scripts-setup/2a-install-openmpi-with-acfl.sh
@@ -15,6 +15,6 @@ tar -xzvf openmpi-4.1.4.tar.gz
 cd openmpi-4.1.4
 mkdir build-acfl
 cd build-acfl
-../configure --prefix=${INSTALLDIR}/openmpi-${OPENMPI_VERSION}-acfl --enable-mpirun-prefix-by-default --with-sge --without-verbs --disable-man-pages --enable-builtin-atomics --with-libfabric=/opt/amazon/efa  --with-libfabric-libdir=/opt/amazon/efa/lib
+../configure --prefix=${INSTALLDIR}/openmpi-${OPENMPI_VERSION}-acfl --enable-mpirun-prefix-by-default --with-sge --without-verbs --disable-man-pages --enable-builtin-atomics --with-libfabric=/opt/amazon/efa  --with-libfabric-libdir=/opt/amazon/efa/lib64
 make -j$(nproc) && make install
 


### PR DESCRIPTION
there is a typo in the libfabric-libdir path: it's /opt/amazon/efa/lib64 and not /opt/amazon/efa/lib (line18)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
