### PR TITLE
Changing SGE for Slurm.

### DIFF
--- a/HPC/README.md
+++ b/HPC/README.md
@@ -152,7 +152,7 @@ tar -xzvf openmpi-4.1.4.tar.gz
 cd openmpi-4.1.4
 mkdir build-acfl
 cd build-acfl
-../configure --prefix=${INSTALLDIR}/openmpi-${OPENMPI_VERSION}-acfl --enable-mpirun-prefix-by-default --with-sge --without-verbs --disable-man-pages --enable-builtin-atomics --with-libfabric=/opt/amazon/efa  --with-libfabric-libdir=/opt/amazon/efa/lib
+../configure --prefix=${INSTALLDIR}/openmpi-${OPENMPI_VERSION}-acfl --enable-mpirun-prefix-by-default --with-slurm --without-verbs --disable-man-pages --enable-builtin-atomics --with-libfabric=/opt/amazon/efa  --with-libfabric-libdir=/opt/amazon/efa/lib
 make -j$(nproc) && make install
 ```
 

--- a/HPC/scripts-setup/2a-install-openmpi-with-acfl.sh
+++ b/HPC/scripts-setup/2a-install-openmpi-with-acfl.sh
@@ -15,6 +15,6 @@ tar -xzvf openmpi-4.1.4.tar.gz
 cd openmpi-4.1.4
 mkdir build-acfl
 cd build-acfl
-../configure --prefix=${INSTALLDIR}/openmpi-${OPENMPI_VERSION}-acfl --enable-mpirun-prefix-by-default --with-sge --without-verbs --disable-man-pages --enable-builtin-atomics --with-libfabric=/opt/amazon/efa  --with-libfabric-libdir=/opt/amazon/efa/lib
+../configure --prefix=${INSTALLDIR}/openmpi-${OPENMPI_VERSION}-acfl --enable-mpirun-prefix-by-default --with-slurm --without-verbs --disable-man-pages --enable-builtin-atomics --with-libfabric=/opt/amazon/efa  --with-libfabric-libdir=/opt/amazon/efa/lib
 make -j$(nproc) && make install
 


### PR DESCRIPTION
Fix #301 

Replace the SGE plugin with Slurm when building OpenMPI.