### PR TITLE
update acfl link and version number, fix typo, make openMPI installat…

### DIFF
--- a/HPC/README.md
+++ b/HPC/README.md
@@ -80,7 +80,7 @@ tar xf arm-compiler-for-linux_23.04_Ubuntu-20.04_aarch64.tar
 
 # load the module to use Arm Compiler for Linux (ACfL)
 module use /shared/arm/modulefiles
-module load acfl/23.04
+module load acfl
 ```
 You will see the following message if ACfL installation is successful.
 ```
@@ -139,7 +139,7 @@ For applications that use the Message Passing Interface (MPI) to communicate, we
 export INSTALLDIR=/shared
 export OPENMPI_VERSION=4.1.4
 module use /shared/arm/modulefiles
-module load acfl/23.04
+module load acfl
 export CC=armclang
 export CXX=armclang++
 export FC=armflang
@@ -152,7 +152,7 @@ tar -xzvf openmpi-4.1.4.tar.gz
 cd openmpi-4.1.4
 mkdir build-acfl
 cd build-acfl
-../configure --prefix=${INSTALLDIR}/openmpi-${OPENMPI_VERSION}-acfl --enable-mpirun-prefix-by-default --with-sge --without-verbs --disable-man-pages --enable-builtin-atomics --with-libfabric=/opt/amazon/efa  --with-libfabric-libdir=/opt/amazon/efa/lib
+../configure --prefix=${INSTALLDIR}/openmpi-${OPENMPI_VERSION}-acfl --enable-mpirun-prefix-by-default --without-verbs --disable-man-pages --enable-builtin-atomics --with-libfabric=/opt/amazon/efa  --with-libfabric-libdir=/opt/amazon/efa/lib
 make -j$(nproc) && make install
 ```
 
@@ -247,7 +247,7 @@ mkdir -p /shared/tools/openfoam-root && cd /shared/tools/openfoam-root
 export PATH=/shared/openmpi-4.1.4-acfl/bin:$PATH
 export LD_LIBRARY_PATH=/shared/openmpi-4.1.4-acfl/lib:$LD_LIBRARY_PATH
 module use /shared/arm/modulefiles 
-module load acfl/23.04 armpl/23.04.0
+module load acfl armpl
 
 [ -d openfoam ] || git clone -b OpenFOAM-v2112 https://develop.openfoam.com/Development/openfoam.git
 [ -d ThirdParty-common ] || git clone -b v2112 https://develop.openfoam.com/Development/ThirdParty-common.git
@@ -259,7 +259,7 @@ popd
 cd openfoam
 
 # a patch required for ACfL or GCC-12 (https://develop.openfoam.com/Development/openfoam/-/commit/91198eaf6a0c11b57446374d97a079ca95cf1412)
-wget https://raw.githubusercontent.com/aws/aws-graviton-getting-started/graviton-hpc-guide/HPC/scripts-openfoam/openfoam-v2112-patch.diff
+wget https://raw.githubusercontent.com/aws/aws-graviton-getting-started/main/HPC/scripts-openfoam/openfoam-v2112-patch.diff
 git apply openfoam-v2112-patch.diff
 
 sed -i -e "s/WM_COMPILER=Gcc/WM_COMPILER=Arm/g" etc/bashrc

--- a/HPC/scripts-gromacs/compile-gromacs-acfl.sh
+++ b/HPC/scripts-gromacs/compile-gromacs-acfl.sh
@@ -17,8 +17,7 @@ CURDIR=${ROOT}/gromacs-${gromacs_version}-acfl
 export PATH=/shared/openmpi-4.1.4-acfl/bin:$PATH
 export LD_LIBRARY_PATH=/shared/openmpi-4.1.4-acfl/lib:$LD_LIBRARY_PATH
 module use /shared/arm/modulefiles
-module load acfl/23.04
-module load armpl/23.04.0
+module load acfl armpl
 
 export LDFLAGS="-lgfortran -lamath -lm -lastring"
 cmake .. -DGMX_BUILD_OWN_FFTW=OFF \

--- a/HPC/scripts-gromacs/sbatch-gromacs-acfl.sh
+++ b/HPC/scripts-gromacs/sbatch-gromacs-acfl.sh
@@ -13,7 +13,7 @@ export LD_LIBRARY_PATH=/shared/gromacs-2022.4-acfl/lib:$LD_LIBRARY_PATH
 export PATH=/shared/openmpi-4.1.4-acfl/bin:$PATH
 export LD_LIBRARY_PATH=/shared/openmpi-4.1.4-acfl/lib:$LD_LIBRARY_PATH
 module use /shared/arm/modulefiles
-module load acfl/23.04 armpl/23.04.0
+module load acfl armpl
 
 [ ! -d /shared/data-gromacs/benchRIB ] && mkdir -p /shared/data-gromacs/benchRIB
 cd /shared/data-gromacs/benchRIB

--- a/HPC/scripts-openfoam/compile-openfoam-acfl.sh
+++ b/HPC/scripts-openfoam/compile-openfoam-acfl.sh
@@ -12,7 +12,7 @@ mkdir -p /shared/tools/openfoam-root && cd /shared/tools/openfoam-root
 export PATH=/shared/openmpi-4.1.4-acfl/bin:$PATH
 export LD_LIBRARY_PATH=/shared/openmpi-4.1.4-acfl/lib:$LD_LIBRARY_PATH
 module use /shared/arm/modulefiles 
-module load acfl/23.04 armpl/23.04.0
+module load acfl armpl
 
 [ -d openfoam ] || git clone -b OpenFOAM-${openfoam_version} https://develop.openfoam.com/Development/openfoam.git
 [ -d ThirdParty-common ] || git clone -b ${openfoam_version} https://develop.openfoam.com/Development/ThirdParty-common.git
@@ -24,7 +24,7 @@ popd
 cd openfoam
 
 # a patch required for ACfL or GCC-12 (https://develop.openfoam.com/Development/openfoam/-/commit/91198eaf6a0c11b57446374d97a079ca95cf1412)
-wget https://raw.githubusercontent.com/aws/aws-graviton-getting-started/graviton-hpc-guide/HPC/scripts-openfoam/openfoam-v2112-patch.diff
+wget https://raw.githubusercontent.com/aws/aws-graviton-getting-started/main/HPC/scripts-openfoam/openfoam-v2112-patch.diff
 git apply openfoam-v2112-patch.diff
 
 sed -i -e "s/WM_COMPILER=Gcc/WM_COMPILER=Arm/g" etc/bashrc

--- a/HPC/scripts-openfoam/sbatch-openfoam-acfl.sh
+++ b/HPC/scripts-openfoam/sbatch-openfoam-acfl.sh
@@ -16,7 +16,7 @@ source $WM_PROJECT_DIR/etc/bashrc
 export PATH=/shared/openmpi-4.1.4-acfl/bin:$PATH
 export LD_LIBRARY_PATH=/shared/openmpi-4.1.4-acfl/lib:$LD_LIBRARY_PATH
 module use /shared/arm/modulefiles 
-module load acfl/23.04 armpl/23.04.0
+module load acfl armpl
 
 workdir=/shared/data-openfoam/motorBike-70M
 mkdir -p $workdir && cd $workdir

--- a/HPC/scripts-setup/0-install-acfl.sh
+++ b/HPC/scripts-setup/0-install-acfl.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 
 # download acfl for ubuntu 20.04 from arm website - https://developer.arm.com/downloads/-/arm-compiler-for-linux
+# please check the download link for the appropriate version
 # install acfl will include armpl automatically
 mkdir -p /shared/tools
 cd /shared/tools
-wget -O arm-compiler-for-linux_23.04_Ubuntu-20.04_aarch64.tar 'https://developer.arm.com/-/media/Files/downloads/hpc/arm-compiler-for-linux/23-04/arm-compiler-for-linux_23.04_Ubuntu-20.04_aarch64.tar?rev=5f0c6e9758aa4409ab9e6a3891c791a4&revision=5f0c6e97-58aa-4409-ab9e-6a3891c791a4'
-tar xf arm-compiler-for-linux_23.04_Ubuntu-20.04_aarch64.tar
-./arm-compiler-for-linux_23.04_Ubuntu-20.04/arm-compiler-for-linux_23.04_Ubuntu-20.04.sh \
+wget -O arm-compiler-for-linux_23.04.1_Ubuntu-20.04_aarch64.tar 'https://developer.arm.com/-/media/Files/downloads/hpc/arm-compiler-for-linux/23-04-1/arm-compiler-for-linux_23.04.1_Ubuntu-20.04_aarch64.tar'
+tar xf arm-compiler-for-linux_23.04.1_Ubuntu-20.04_aarch64.tar
+./arm-compiler-for-linux_23.04.1_Ubuntu-20.04/arm-compiler-for-linux_23.04.1_Ubuntu-20.04.sh \
 -i /shared/arm -a --force

--- a/HPC/scripts-setup/1-install-armpl.sh
+++ b/HPC/scripts-setup/1-install-armpl.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
 # Find the download link to ArmPL (Ubuntu 20.04, GCC-12) on https://developer.arm.com/downloads/-/arm-performance-libraries
+# please check the download link for the appropriate version
 mkdir -p /shared/tools && cd /shared/tools
-wget -O arm-performance-libraries_23.04_Ubuntu-20.04_gcc-10.2.tar 'https://developer.arm.com/-/media/Files/downloads/hpc/arm-performance-libraries/23-04/ubuntu-20/arm-performance-libraries_23.04_Ubuntu-20.04_gcc-12.2.tar?rev=defaf45ca17644dea20dc54a5a0327ed&revision=defaf45c-a176-44de-a20d-c54a5a0327ed'
+wget -O arm-performance-libraries_23.04_Ubuntu-20.04_gcc-10.2.tar 'https://developer.arm.com/-/media/Files/downloads/hpc/arm-performance-libraries/23-04/ubuntu-20/arm-performance-libraries_23.04_Ubuntu-20.04_gcc-12.2.tar'
 tar xf arm-performance-libraries_23.04_Ubuntu-20.04_gcc-10.2.tar
 cd arm-performance-libraries_23.04_Ubuntu-20.04/
 ./arm-performance-libraries_23.04_Ubuntu-20.04.sh -i /shared/arm -a --force

--- a/HPC/scripts-setup/2a-install-openmpi-with-acfl.sh
+++ b/HPC/scripts-setup/2a-install-openmpi-with-acfl.sh
@@ -4,17 +4,30 @@
 export INSTALLDIR=/shared
 export OPENMPI_VERSION=4.1.4
 module use /shared/arm/modulefiles
-module load acfl/23.04
+module load acfl
 export CC=armclang
 export CXX=armclang++
 export FC=armflang
 export CFLAGS="-mcpu=neoverse-512tvb"
+
+OS_NAME=unknown
+grep -iq "Amazon Linux 2" /etc/os-release 2>/dev/null && OS_NAME=alinux2
+grep -iq "Ubuntu 20.04.6 LTS" /etc/os-release 2>/dev/null && OS_NAME=ubuntu
+
+if [ "$OS_NAME" = "alinux2" ]
+then
+	EFA_LIB_DIR=/opt/amazon/efa/lib64
+elif [ "$OS_NAME" = "ubuntu" ]
+then
+	EFA_LIB_DIR=/opt/amazon/efa/lib
+fi
+
 cd /shared/tools
 wget -N https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-4.1.4.tar.gz
 tar -xzvf openmpi-4.1.4.tar.gz
 cd openmpi-4.1.4
 mkdir build-acfl
 cd build-acfl
-../configure --prefix=${INSTALLDIR}/openmpi-${OPENMPI_VERSION}-acfl --enable-mpirun-prefix-by-default --with-sge --without-verbs --disable-man-pages --enable-builtin-atomics --with-libfabric=/opt/amazon/efa  --with-libfabric-libdir=/opt/amazon/efa/lib
+../configure --prefix=${INSTALLDIR}/openmpi-${OPENMPI_VERSION}-acfl --enable-mpirun-prefix-by-default --without-verbs --disable-man-pages --enable-builtin-atomics --with-libfabric=/opt/amazon/efa  --with-libfabric-libdir=${EFA_LIB_DIR}
 make -j$(nproc) && make install
 

--- a/HPC/scripts-setup/2b-install-openmpi-with-gcc.sh
+++ b/HPC/scripts-setup/2b-install-openmpi-with-gcc.sh
@@ -7,12 +7,24 @@ export CC=gcc
 export CXX=g++
 export FC=gfortran
 export CFLAGS="-march=native"
+OS_NAME=unknown
+grep -iq "Amazon Linux 2" /etc/os-release 2>/dev/null && OS_NAME=alinux2
+grep -iq "Ubuntu 20.04.6 LTS" /etc/os-release 2>/dev/null && OS_NAME=ubuntu
+
+if [ "$OS_NAME" = "alinux2" ]
+then
+	EFA_LIB_DIR=/opt/amazon/efa/lib64
+elif [ "$OS_NAME" = "ubuntu" ]
+then
+	EFA_LIB_DIR=/opt/amazon/efa/lib
+fi
+
 cd /shared/tools
 wget -N https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-4.1.4.tar.gz
 tar -xzvf openmpi-4.1.4.tar.gz
 cd openmpi-4.1.4
 mkdir build
 cd build
-../configure --prefix=${INSTALLDIR}/openmpi-${OPENMPI_VERSION} --enable-mpirun-prefix-by-default --with-sge --without-verbs --disable-man-pages --enable-builtin-atomics --with-libfabric=/opt/amazon/efa  --with-libfabric-libdir=/opt/amazon/efa/lib
+../configure --prefix=${INSTALLDIR}/openmpi-${OPENMPI_VERSION} --enable-mpirun-prefix-by-default --without-verbs --disable-man-pages --enable-builtin-atomics --with-libfabric=/opt/amazon/efa  --with-libfabric-libdir=/opt/amazon/efa/lib
 make -j$(nproc) && make install
 

--- a/HPC/scripts-setup/install-tools-headnode-ubuntu2004.sh
+++ b/HPC/scripts-setup/install-tools-headnode-ubuntu2004.sh
@@ -5,16 +5,16 @@ set -e
 # install acfl will include armpl automatically
 mkdir -p /shared/tools
 cd /shared/tools
-wget -O arm-compiler-for-linux_23.04_Ubuntu-20.04_aarch64.tar 'https://developer.arm.com/-/media/Files/downloads/hpc/arm-compiler-for-linux/23-04/arm-compiler-for-linux_23.04_Ubuntu-20.04_aarch64.tar?rev=5f0c6e9758aa4409ab9e6a3891c791a4&revision=5f0c6e97-58aa-4409-ab9e-6a3891c791a4'
-tar xf arm-compiler-for-linux_23.04_Ubuntu-20.04_aarch64.tar
-./arm-compiler-for-linux_23.04_Ubuntu-20.04/arm-compiler-for-linux_23.04_Ubuntu-20.04.sh \
+wget -O arm-compiler-for-linux_23.04.1_Ubuntu-20.04_aarch64.tar 'https://developer.arm.com/-/media/Files/downloads/hpc/arm-compiler-for-linux/23-04-1/arm-compiler-for-linux_23.04.1_Ubuntu-20.04_aarch64.tar?rev=52971e8fa8a8498c834e48776dfd1ca5&revision=52971e8f-a8a8-498c-834e-48776dfd1ca5'
+tar xf arm-compiler-for-linux_23.04.1_Ubuntu-20.04_aarch64.tar
+./arm-compiler-for-linux_23.04.1_Ubuntu-20.04/arm-compiler-for-linux_23.04.1_Ubuntu-20.04.sh \
 -i /shared/arm -a --force
 
 # compile a copy of Open MPI with ACFL
 export INSTALLDIR=/shared
 export OPENMPI_VERSION=4.1.4
 module use /shared/arm/modulefiles
-module load acfl/23.04
+module load acfl
 export CC=armclang
 export CXX=armclang++
 export FC=armflang

--- a/HPC/scripts-wrf/0-install_zlib_1p2.sh
+++ b/HPC/scripts-wrf/0-install_zlib_1p2.sh
@@ -2,7 +2,7 @@
 
 export WRF_INSTALL=/shared
 module use /shared/arm/modulefiles
-module load acfl/23.04 armpl/23.04.0
+module load acfl armpl
 export OPENMPI_VERSION=4.1.4
 export CC=armclang
 export CXX=armclang++

--- a/HPC/scripts-wrf/1-install_hdf5_1p12.sh
+++ b/HPC/scripts-wrf/1-install_hdf5_1p12.sh
@@ -2,7 +2,7 @@
 
 export WRF_INSTALL=/shared
 module use /shared/arm/modulefiles
-module load acfl/23.04 armpl/23.04.0
+module load acfl armpl
 export OPENMPI_VERSION=4.1.4
 export PATH=${WRF_INSTALL}/openmpi-${OPENMPI_VERSION}-acfl/bin:$PATH
 export LD_LIBRARY_PATH=${WRF_INSTALL}/openmpi-${OPENMPI_VERSION}-acfl/lib:$LD_LIBRARY_PATH

--- a/HPC/scripts-wrf/2-install_pnetcdf.sh
+++ b/HPC/scripts-wrf/2-install_pnetcdf.sh
@@ -2,7 +2,7 @@
 
 export WRF_INSTALL=/shared
 module use /shared/arm/modulefiles
-module load acfl/23.04 armpl/23.04.0
+module load acfl armpl
 export OPENMPI_VERSION=4.1.4
 export PATH=${WRF_INSTALL}/openmpi-${OPENMPI_VERSION}-acfl/bin:$PATH
 export LD_LIBRARY_PATH=${WRF_INSTALL}/openmpi-${OPENMPI_VERSION}-acfl/lib:$LD_LIBRARY_PATH

--- a/HPC/scripts-wrf/3-install_netcdf_c.sh
+++ b/HPC/scripts-wrf/3-install_netcdf_c.sh
@@ -2,7 +2,7 @@
 
 export WRF_INSTALL=/shared
 module use /shared/arm/modulefiles
-module load acfl/23.04 armpl/23.04.0
+module load acfl armpl
 export OPENMPI_VERSION=4.1.4
 export PATH=${WRF_INSTALL}/openmpi-${OPENMPI_VERSION}-acfl/bin:$PATH
 export LD_LIBRARY_PATH=${WRF_INSTALL}/openmpi-${OPENMPI_VERSION}-acfl/lib:$LD_LIBRARY_PATH

--- a/HPC/scripts-wrf/4-install_netcdf_fortran.sh
+++ b/HPC/scripts-wrf/4-install_netcdf_fortran.sh
@@ -2,7 +2,7 @@
 
 export WRF_INSTALL=/shared
 module use /shared/arm/modulefiles
-module load acfl/23.04 armpl/23.04.0
+module load acfl armpl
 export OPENMPI_VERSION=4.1.4
 export PATH=${WRF_INSTALL}/openmpi-${OPENMPI_VERSION}-acfl/bin:$PATH
 export LD_LIBRARY_PATH=${WRF_INSTALL}/openmpi-${OPENMPI_VERSION}-acfl/lib:$LD_LIBRARY_PATH

--- a/HPC/scripts-wrf/compile-wrf-v45-acfl.sh
+++ b/HPC/scripts-wrf/compile-wrf-v45-acfl.sh
@@ -5,7 +5,7 @@
 export WRF_INSTALL=/shared
 export CURDIR=/shared/wrf-arm-v45-acfl
 module use /shared/arm/modulefiles
-module load acfl/23.04 armpl/23.04.0
+module load acfl armpl
 export OPENMPI_VERSION=4.1.4
 export PATH=${WRF_INSTALL}/openmpi-${OPENMPI_VERSION}-acfl/bin:$PATH
 export LD_LIBRARY_PATH=${WRF_INSTALL}/openmpi-${OPENMPI_VERSION}-acfl/lib:$LD_LIBRARY_PATH
@@ -35,7 +35,7 @@ git clone https://github.com/wrf-model/WRF.git
 cd WRF && git checkout release-v4.5
 
 # apply a patch for ACFL compiler options
-wget https://raw.githubusercontent.com/aws/aws-graviton-getting-started/graviton-hpc-guide/HPC/scripts-wrf/WRF-v45-patch-acfl.diff
+wget https://raw.githubusercontent.com/aws/aws-graviton-getting-started/main/HPC/scripts-wrf/WRF-v45-patch-acfl.diff
 git apply WRF-v45-patch-acfl.diff
 
 # choose option '12. (dm+sm)   armclang (armflang/armclang): Aarch64' and '1=basic'

--- a/HPC/scripts-wrf/install-wrf-tools-acfl.sh
+++ b/HPC/scripts-wrf/install-wrf-tools-acfl.sh
@@ -3,7 +3,7 @@ set -e
 
 export WRF_INSTALL=/shared
 module use /shared/arm/modulefiles
-module load acfl/23.04 armpl/23.04.0
+module load acfl armpl
 export OPENMPI_VERSION=4.1.4
 export PATH=${WRF_INSTALL}/openmpi-${OPENMPI_VERSION}-acfl/bin:$PATH
 export LD_LIBRARY_PATH=${WRF_INSTALL}/openmpi-${OPENMPI_VERSION}-acfl/lib:$LD_LIBRARY_PATH

--- a/HPC/scripts-wrf/sbatch-wrf-v45-acfl.sh
+++ b/HPC/scripts-wrf/sbatch-wrf-v45-acfl.sh
@@ -19,7 +19,7 @@ export FI_EFA_FORK_SAFE=1
 wrf_root=/shared
 wrf_install=${wrf_root}
 module use /shared/arm/modulefiles
-module load armpl/23.04.0 acfl/23.04
+module load acfl armpl
 
 export PATH=${wrf_install}/openmpi-4.1.4-acfl/bin:$PATH
 export LD_LIBRARY_PATH=${wrf_install}/openmpi-4.1.4-acfl/lib:$LD_LIBRARY_PATH


### PR DESCRIPTION
* Update the link to the latest ACfL (23.04.1)
* Update Open MPI scripts to be compatible with AL2; remove SGE support from Open MPI build
* Fix typo in the link to the patch

