### PR TITLE
Update librdkafka.md with minimum version requirement to 2.3.0

### DIFF
--- a/software/librdkafka.md
+++ b/software/librdkafka.md
@@ -27,7 +27,7 @@ logout
 Next, log back into the instance, and run:
 
 ```sh
-export LIBRDKAFKA_VERSION=2.0.2 # Or whichever version you need. We tested with 2.0.2.
+export LIBRDKAFKA_VERSION=2.3.0   #The minimum version required is 2.3.0
 git clone -b v${LIBRDKAFKA_VERSION} https://github.com/confluentinc/librdkafka 
 cd librdkafka/packaging/rpm
 MOCK_CONFIG=/etc/mock/amazonlinux-2-aarch64.cfg make


### PR DESCRIPTION
Upon using 2.0.2 throws below error
#error "confluent-kafka-python requires librdkafka v2.3.0 or later. Install the latest version of librdkafka from the Confluent repositories, see http://docs.confluent.io/current/installation.html"

The minimum version required is 2.3.0 for both python 2 and 3. Tried and tested with both python2 and python3.7  for librdkafka 2.3.0

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
