### PR TITLE
perfrunbook utility fixes

### DIFF
--- a/perfrunbook/utilities/capture_flamegraphs.sh
+++ b/perfrunbook/utilities/capture_flamegraphs.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
-
 set -e
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 
 let capture_freq=99
 reverse=
 
-# search replace filter that will combine thread names like 
+# search replace filter that will combine thread names like
 # GC-Thread-1 to GC-Thread- in perf-script sample header lines.
 sr_filter='s/^([a-zA-Z\-]+)[0-9]*-?([a-zA-z]*) (.*?)$/\1\2 \3/g'
 
@@ -18,12 +19,11 @@ help_msg() {
 process_perf_data () {
   perf inject -j -i perf.data -o perf.data.jit
   perf script -f -i perf.data.jit > script.out
-  
   if [[ ! -z "${sr_filter}" ]]; then
     perl -pi -e "${sr_filter}" script.out
   fi
-  ./FlameGraph/stackcollapse-perf.pl --kernel --jit script.out > folded.out
-  ./FlameGraph/flamegraph.pl ${reverse:+--reverse} --colors java folded.out > flamegraph_$1_$4_$3_$2.svg
+  "$script_dir/FlameGraph/stackcollapse-perf.pl" --kernel --jit script.out > folded.out
+  "$script_dir/FlameGraph/flamegraph.pl" ${reverse:+--reverse} --colors java folded.out > flamegraph_$1_$4_$3_$2.svg
   rm perf.data perf.data.jit script.out folded.out
 }
 

--- a/perfrunbook/utilities/capture_flamegraphs.sh
+++ b/perfrunbook/utilities/capture_flamegraphs.sh
@@ -54,12 +54,6 @@ if [[ $? -ne 0 ]]; then
   exit 1
 fi
 
-date=$(date "+%Y-%m-%d_%H:%M:%S")
-# Get meta-data using IMDSv2
-token=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
-instance_type=$(curl -s -H "X-aws-ec2-metadata-token: $token" http://169.254.169.254/latest/meta-data/instance-type)
-instance_id=$(curl -s -H "X-aws-ec2-metadata-token: $token" http://169.254.169.254/latest/meta-data/instance-id)
-
 POSITIONAL=()
 while [[ $# -gt 0 ]]
 do
@@ -97,6 +91,16 @@ fi
 capture_time=300
 if [[ $# -gt 1 ]]; then
   capture_time=$2
+fi
+
+date=$(date "+%Y-%m-%d_%H:%M:%S")
+# Try to get meta-data using IMDSv2
+if token=$(curl --max-time 1 -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600") ; then
+  instance_type=$(curl -s -H "X-aws-ec2-metadata-token: $token" http://169.254.169.254/latest/meta-data/instance-type)
+  instance_id=$(curl -s -H "X-aws-ec2-metadata-token: $token" http://169.254.169.254/latest/meta-data/instance-id)
+else
+  instance_type="unknown"
+  instance_id="unknown"
 fi
 
 if [[ "$1" == "oncpu" ]]; then

--- a/perfrunbook/utilities/measure_and_plot_basic_pmu_counters.py
+++ b/perfrunbook/utilities/measure_and_plot_basic_pmu_counters.py
@@ -197,13 +197,13 @@ if __name__ == "__main__":
     parser.add_argument("--no-root", action="store_true", help="Allow running without root privileges")
 
 
+    args = parser.parse_args()
+
     if not args.no_root:
         res = subprocess.run(["id", "-u"], check=True, stdout=subprocess.PIPE)
         if int(res.stdout) > 0:
             print("Must be run with root privileges (or with --no-root)")
             exit(1)
-
-    args = parser.parse_args()
 
     if args.custom_ctr:
         ctrs = args.custom_ctr.split("|")


### PR DESCRIPTION
## measure_and_plot_basic_pmu_counters.py
- fix issue where the 'no-root' logic was trying to read 'args' before it existed

This is a simple bug that got introduced a while back.
```
# ./aws-graviton-getting-started/perfrunbook/utilities/measure_and_plot_basic_pmu_counters.py
Traceback (most recent call last):
  File "./aws-graviton-getting-started/perfrunbook/utilities/measure_and_plot_basic_pmu_counters.py", line 200, in <module>
    if not args.no_root:
NameError: name 'args' is not defined
```

## capture_flamegraphs.sh
- don't get hung up if IMDS isn't available (e.g. in a container)
- don't depend on this script being run from the 'utilities' directory

Previously, the script would get hung up on a 2-minute curl timeout if you were running in a context without IMDS, such as in a container. Now if IMDS is not available within 1 second curl times out and 'unknown' is used instead
```
# time ./aws-graviton-getting-started/perfrunbook/utilities/capture_flamegraphs.sh oncpu 5
[ perf record: Woken up 1 times to write data ]
[ perf record: Captured and wrote 0.693 MB perf.data (5463 samples) ]

real	0m7.720s
user	0m0.345s
sys	0m0.429s

# ls flamegraph_oncpu_*
flamegraph_oncpu_unknown_unknown_2024-04-24_17:07:35.svg
```
Also, the IMDS calls would happen even if you were going to wind up getting a usage message. That is also fixed (the below is in a container without IMDS)
```
# time ./aws-graviton-getting-started/perfrunbook/utilities/capture_flamegraphs.sh --help
Requires perf to be installed and in your PATH
usage: ./aws-graviton-getting-started/perfrunbook/utilities/capture_flamegraphs.sh oncpu|offcpu|<custom_event> [time seconds|default 300] --f|--frequency 99 -R|--Reverse -r|--regexfilter 's/hi/bye/g'
custom_event is any event listed in perf-list

real	0m0.047s
user	0m0.014s
sys	0m0.016s
```

I also made the script work if invoked with a PWD != its directory. The error was
```
# ./aws-graviton-getting-started/perfrunbook/utilities/capture_flamegraphs.sh oncpu 5
[ perf record: Woken up 1 times to write data ]
[ perf record: Captured and wrote 0.775 MB perf.data (6140 samples) ]
./aws-graviton-getting-started/perfrunbook/utilities/capture_flamegraphs.sh: line 25: ./FlameGraph/stackcollapse-perf.pl: No such file or directory
```
and now it works
```
$ time sudo ./capture_flamegraphs.sh oncpu 5
[ perf record: Woken up 1 times to write data ]
[ perf record: Captured and wrote 1.150 MB perf.data (7920 samples) ]

real	0m6.647s
user	0m0.019s
sys	0m0.008s

$ ls flamegraph_oncpu_*
flamegraph_oncpu_i-02d6037b21b4f2b62_c7g.4xlarge_2024-04-24_17:08:49.svg
```
