### PR TITLE
hpc: Add Cradle CFD (2024.1) to list of ISVs with Graviton support

### DIFF
--- a/HPC/README.md
+++ b/HPC/README.md
@@ -586,3 +586,4 @@ Siemens               | StarCCM++     | 2023.2              | [Release Notes](ht
 Université de Genève  | Palabos       | 2010                | [Lattice-Boltzmann Palabos (AWS)](https://aws.amazon.com/blogs/hpc/lattice-boltzmann-simulation-with-palabos-on-aws-using-graviton-based-amazon-ec2-hpc7g-instances/)
 Altair Engineering  | OpenRadioss       | 20231204                | [Presentations-Aachen270623 - OpenRadioss](https://www.openradioss.org/presentations-aachen270623/?wvideo=3ox1rtpco8), [Instructions](https://openradioss.atlassian.net/wiki/spaces/OPENRADIOSS/pages/47546369/HPC+Benchmark+Models)
 Électricité de France   | Code Saturne       | 8.0.2                | https://www.code-saturne.org/cms/web/documentation/Tutorials
+HEXAGON               | Cradle CFD           | 2024.1               | [Release Notes](https://simcompanion.hexagon.com/customers/s/article/What-s-New-in-Cradle-CFD-2024-1)


### PR DESCRIPTION
Add Cradle CFD (2024.1) to list of ISVs with Graviton support


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
