### PR TITLE
Add tools/skills: Agent Skills for Graviton migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This repository provides technical guidance for users and developers using [Amaz
 * [AWS Managed Services available on Graviton](managed_services.md)
 * [Graviton Performance Runbook](perfrunbook/README.md)
 * [Assembly Optimization Guide for Graviton Arm64 Processors](arm64-assembly-optimization.md)
+* [Tools and Agent Skills](tools/README.md)
 * [Additional resources](#additional-resources)
 * [How To Resources](howtoresources.md)
 * [Blog Posts](#blog-posts)
@@ -213,6 +214,15 @@ NOTE: Linux versions of OpenJDK and Amazon Corretto 17+ dynamically link to zlib
 
 ## Other
  * [Lower Latency and Costs Using AWS Graviton2–Based Instances with Sprinklr](https://aws.amazon.com/solutions/case-studies/sprinklr-case-study/)
+
+# Tools and Agent Skills
+
+[Agent Skills](tools/skills/README.md) are portable instruction packages that AI coding assistants can follow to perform Graviton migrations. They work across 20+ platforms including Claude Code, Kiro, Cursor, Codex, Windsurf, Gemini CLI, and GitHub Copilot.
+
+Available skills:
+ * [Java x86-to-Graviton migration](tools/skills/languages/java-x86-to-graviton/) - dependency audit, native library validation, JVM optimization, ARM64 build validation
+
+See [tools/skills/README.md](tools/skills/README.md) for installation instructions and the full catalogue.
 
 # Additional resources
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -57,6 +57,12 @@
 * [Assembly Optimization Guide for Graviton Arm64 Processors](arm64-assembly-optimization.md)
 * [Profiling](Monitoring_Tools_on_Graviton.md)
 
+# Tools
+
+* [Overview](tools/README.md)
+* [Agent Skills](tools/skills/README.md)
+    * [Java x86-to-Graviton Migration](tools/skills/languages/java-x86-to-graviton/SKILL.md)
+
 -----------
 
 [How To Resources](howtoresources.md)

--- a/howtoresources.md
+++ b/howtoresources.md
@@ -22,6 +22,7 @@ If you are just getting started with AWS Graviton-based instances, or even if yo
 * [Transforming Java applications with Amazon Q Developer](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/transform-java.html)
 * [Transforming .NET applications with Amazon Q Developer](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/transform-dotnet-IDE.html)
 * Source Code Analysis - [Porting Advisor for Graviton](https://github.com/aws/porting-advisor-for-graviton)
+* AI-Assisted Migration - [Graviton Agent Skills](tools/skills/README.md)
 
 ### Building / Running applications on AWS Graviton
 

--- a/java.md
+++ b/java.md
@@ -284,3 +284,7 @@ $ cd linux-*.amzn2.aarch64
 $ cd tools/perf
 $ make
 ```
+
+### Agent Skills for Java Migration
+
+To automate the x86-to-Graviton migration process using an AI coding assistant (Claude Code, Kiro, Cursor, Codex, Windsurf, and others), use the [Java x86-to-Graviton Agent Skill](tools/skills/languages/java-x86-to-graviton/). It walks an agent through dependency auditing, native library validation, JVM flag configuration, and ARM64 build validation. See [tools/skills/README.md](tools/skills/README.md) for installation instructions.

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,11 @@
+# Tools
+
+Developer tooling that complements the existing [Graviton optimization guides](../README.md).
+
+## Contents
+
+### [Agent Skills](skills/)
+
+Portable instruction packages (SKILL.md format) for AI coding assistants. These skills encode Graviton migration expertise into a format that works across 20+ platforms including Claude Code, Kiro, Cursor, Codex, Windsurf, Gemini CLI, GitHub Copilot, and more.
+
+See [tools/skills/README.md](skills/README.md) for the full catalogue and usage instructions.

--- a/tools/skills/README.md
+++ b/tools/skills/README.md
@@ -1,0 +1,40 @@
+# Graviton Agent Skills
+
+Portable Agent Skills that help developers migrate codebases to AWS Graviton (ARM64) processors.
+
+## What are Agent Skills?
+
+Agent Skills are an open standard for packaging expert instructions in a format AI coding assistants can follow. Each skill is a `SKILL.md` file (with optional supporting documents) that teaches an agent how to perform a specific task — in this case, migrating applications to Graviton.
+
+Skills work on 20+ platforms: Claude Code, Kiro, Cursor, Codex, Windsurf, Gemini CLI, GitHub Copilot, and more.
+
+For the full specification, see [agentskills.io](https://agentskills.io).
+
+## Available Skills
+
+| Skill | Language | Status | Description |
+|-------|----------|--------|-------------|
+| [java-x86-to-graviton](languages/java-x86-to-graviton/) | Java | Stable | Full x86-to-Graviton migration: dependency audit, native library validation, JVM optimization, ARM64 build validation |
+
+## How to Use
+
+### Import into your project
+
+Copy the skill folder into your project repository:
+
+```bash
+# Copy the Java Graviton migration skill
+cp -r tools/skills/languages/java-x86-to-graviton/ /path/to/your/project/.skills/java-x86-to-graviton/
+```
+
+Your AI coding assistant will detect the `SKILL.md` and follow the instructions when triggered.
+
+### Direct reference
+
+Point your AI assistant to the skill directly:
+
+> Analyze this Java project for Graviton migration using the skill at tools/skills/languages/java-x86-to-graviton/SKILL.md
+
+## Creating New Skills
+
+See the [skill template](_templates/SKILL.template.md) for the boilerplate structure. Fill in language-specific details based on the existing [Graviton documentation](../../README.md) for each language.

--- a/tools/skills/README.md
+++ b/tools/skills/README.md
@@ -32,7 +32,7 @@ Both files contain the same instructions — only the frontmatter differs. Your 
 Open the **Agent Steering & Skills** panel, click **+** > **Import a skill** > **GitHub**, and paste:
 
 ```
-https://github.com/jcwolfaws/aws-graviton-getting-started/tree/main/tools/skills/languages/java-x86-to-graviton
+https://github.com/aws/aws-graviton-getting-started/tree/main/tools/skills/languages/java-x86-to-graviton
 ```
 
 ### Cursor
@@ -40,13 +40,13 @@ https://github.com/jcwolfaws/aws-graviton-getting-started/tree/main/tools/skills
 Open **Settings** (`Cmd+Shift+J` / `Ctrl+Shift+J`) > **Rules** > **Add Rule** > **Remote Rule (GitHub)** and paste:
 
 ```
-https://github.com/jcwolfaws/aws-graviton-getting-started/tree/main/tools/skills/languages/java-x86-to-graviton
+https://github.com/aws/aws-graviton-getting-started/tree/main/tools/skills/languages/java-x86-to-graviton
 ```
 
 ### Claude Code
 
 ```bash
-git clone --filter=blob:none --sparse https://github.com/jcwolfaws/aws-graviton-getting-started.git /tmp/graviton-skill && \
+git clone --filter=blob:none --sparse https://github.com/aws/aws-graviton-getting-started.git /tmp/graviton-skill && \
   cd /tmp/graviton-skill && \
   git sparse-checkout set tools/skills/languages/java-x86-to-graviton && \
   cp -r tools/skills/languages/java-x86-to-graviton ~/.claude/skills/ && \
@@ -56,7 +56,7 @@ git clone --filter=blob:none --sparse https://github.com/jcwolfaws/aws-graviton-
 ### GitHub Copilot / VS Code
 
 ```bash
-git clone --filter=blob:none --sparse https://github.com/jcwolfaws/aws-graviton-getting-started.git /tmp/graviton-skill && \
+git clone --filter=blob:none --sparse https://github.com/aws/aws-graviton-getting-started.git /tmp/graviton-skill && \
   cd /tmp/graviton-skill && \
   git sparse-checkout set tools/skills/languages/java-x86-to-graviton && \
   mkdir -p .github/skills && \
@@ -67,7 +67,7 @@ git clone --filter=blob:none --sparse https://github.com/jcwolfaws/aws-graviton-
 ### OpenAI Codex
 
 ```bash
-git clone --filter=blob:none --sparse https://github.com/jcwolfaws/aws-graviton-getting-started.git /tmp/graviton-skill && \
+git clone --filter=blob:none --sparse https://github.com/aws/aws-graviton-getting-started.git /tmp/graviton-skill && \
   cd /tmp/graviton-skill && \
   git sparse-checkout set tools/skills/languages/java-x86-to-graviton && \
   mkdir -p ~/.codex/skills && \
@@ -78,7 +78,7 @@ git clone --filter=blob:none --sparse https://github.com/jcwolfaws/aws-graviton-
 ### Windsurf
 
 ```bash
-git clone --filter=blob:none --sparse https://github.com/jcwolfaws/aws-graviton-getting-started.git /tmp/graviton-skill && \
+git clone --filter=blob:none --sparse https://github.com/aws/aws-graviton-getting-started.git /tmp/graviton-skill && \
   cd /tmp/graviton-skill && \
   git sparse-checkout set tools/skills/languages/java-x86-to-graviton && \
   mkdir -p .windsurf/skills && \
@@ -89,7 +89,7 @@ git clone --filter=blob:none --sparse https://github.com/jcwolfaws/aws-graviton-
 ### Gemini CLI
 
 ```bash
-git clone --filter=blob:none --sparse https://github.com/jcwolfaws/aws-graviton-getting-started.git /tmp/graviton-skill && \
+git clone --filter=blob:none --sparse https://github.com/aws/aws-graviton-getting-started.git /tmp/graviton-skill && \
   cd /tmp/graviton-skill && \
   git sparse-checkout set tools/skills/languages/java-x86-to-graviton && \
   mkdir -p ~/.gemini/skills && \
@@ -100,7 +100,7 @@ git clone --filter=blob:none --sparse https://github.com/jcwolfaws/aws-graviton-
 ### Roo Code
 
 ```bash
-git clone --filter=blob:none --sparse https://github.com/jcwolfaws/aws-graviton-getting-started.git /tmp/graviton-skill && \
+git clone --filter=blob:none --sparse https://github.com/aws/aws-graviton-getting-started.git /tmp/graviton-skill && \
   cd /tmp/graviton-skill && \
   git sparse-checkout set tools/skills/languages/java-x86-to-graviton && \
   mkdir -p .roo/skills && \
@@ -111,7 +111,7 @@ git clone --filter=blob:none --sparse https://github.com/jcwolfaws/aws-graviton-
 ### Goose
 
 ```bash
-git clone --filter=blob:none --sparse https://github.com/jcwolfaws/aws-graviton-getting-started.git /tmp/graviton-skill && \
+git clone --filter=blob:none --sparse https://github.com/aws/aws-graviton-getting-started.git /tmp/graviton-skill && \
   cd /tmp/graviton-skill && \
   git sparse-checkout set tools/skills/languages/java-x86-to-graviton && \
   mkdir -p ~/.config/goose/skills && \
@@ -124,7 +124,7 @@ git clone --filter=blob:none --sparse https://github.com/jcwolfaws/aws-graviton-
 Copy the skill folder into the cross-platform standard path:
 
 ```bash
-git clone --filter=blob:none --sparse https://github.com/jcwolfaws/aws-graviton-getting-started.git /tmp/graviton-skill && \
+git clone --filter=blob:none --sparse https://github.com/aws/aws-graviton-getting-started.git /tmp/graviton-skill && \
   cd /tmp/graviton-skill && \
   git sparse-checkout set tools/skills/languages/java-x86-to-graviton && \
   mkdir -p .agents/skills && \

--- a/tools/skills/README.md
+++ b/tools/skills/README.md
@@ -4,11 +4,20 @@ Portable Agent Skills that help developers migrate codebases to AWS Graviton (AR
 
 ## What are Agent Skills?
 
-Agent Skills are an open standard for packaging expert instructions in a format AI coding assistants can follow. Each skill is a `SKILL.md` file (with optional supporting documents) that teaches an agent how to perform a specific task — in this case, migrating applications to Graviton.
-
-Skills work on 20+ platforms: Claude Code, Kiro, Cursor, Codex, Windsurf, Gemini CLI, GitHub Copilot, and more.
+Agent Skills are an open standard for packaging expert instructions in a format AI coding assistants can follow. Each skill is a folder containing instructions, references, and scripts that teach an agent how to perform a specific task — in this case, migrating applications to Graviton.
 
 For the full specification, see [agentskills.io](https://agentskills.io).
+
+## Platform Compatibility
+
+Each skill folder contains two entry point files to support the broadest range of AI tools:
+
+| File | Platforms | Format |
+|------|-----------|--------|
+| `SKILL.md` | Claude Code, Cursor, Codex, Windsurf, Gemini CLI, GitHub Copilot, and [20+ others](https://agentskills.io) | [Agent Skills spec](https://agentskills.io/specification) |
+| `POWER.md` | Kiro | Kiro Powers format (`displayName`, `keywords`, `author` frontmatter) |
+
+Both files contain the same instructions — only the frontmatter differs. Your platform will pick up the file it recognizes and ignore the other.
 
 ## Available Skills
 
@@ -16,14 +25,21 @@ For the full specification, see [agentskills.io](https://agentskills.io).
 |-------|----------|--------|-------------|
 | [java-x86-to-graviton](languages/java-x86-to-graviton/) | Java | Stable | Full x86-to-Graviton migration: dependency audit, native library validation, JVM optimization, ARM64 build validation |
 
-## How to Use
+## How to Install
 
-### Import into your project
+### Kiro
 
-Copy the skill folder into your project repository:
+Paste the GitHub folder URL into Kiro's power installer:
+
+```
+https://github.com/jcwolfaws/aws-graviton-getting-started/tree/main/tools/skills/languages/java-x86-to-graviton
+```
+
+### Claude Code, Cursor, Codex, and other Agent Skills platforms
+
+Copy the skill folder into your project:
 
 ```bash
-# Copy the Java Graviton migration skill
 cp -r tools/skills/languages/java-x86-to-graviton/ /path/to/your/project/.skills/java-x86-to-graviton/
 ```
 
@@ -31,10 +47,32 @@ Your AI coding assistant will detect the `SKILL.md` and follow the instructions 
 
 ### Direct reference
 
-Point your AI assistant to the skill directly:
+You can also point your AI assistant to the skill without installing:
 
 > Analyze this Java project for Graviton migration using the skill at tools/skills/languages/java-x86-to-graviton/SKILL.md
 
+## Skill Folder Structure
+
+Each skill folder contains:
+
+```
+<skill-name>/
+├── SKILL.md                    # Entry point (Agent Skills format)
+├── POWER.md                    # Entry point (Kiro format)
+├── summaries.md                # File index for agent discovery
+├── phases/                     # Detailed phase instructions
+├── document_references/        # Scope guardrails and output standards
+└── README.md                   # Human-readable overview
+```
+
 ## Creating New Skills
 
-See the [skill template](_templates/SKILL.template.md) for the boilerplate structure. Fill in language-specific details based on the existing [Graviton documentation](../../README.md) for each language.
+See the [skill template](_templates/SKILL.template.md) for the boilerplate structure. When creating a new skill:
+
+1. Create a folder under `languages/` named to match the skill's `name` field
+2. Create both `SKILL.md` (Agent Skills frontmatter) and `POWER.md` (Kiro frontmatter) with the same body content
+3. Add a `summaries.md` listing all files in the skill for agent discovery
+4. Add a `README.md` with a human-readable overview
+5. Keep the main entry point under 500 lines — split detailed instructions into `phases/`, `references/`, or `scripts/` subdirectories
+
+Fill in language-specific details based on the existing [Graviton documentation](../../README.md) for each language.

--- a/tools/skills/README.md
+++ b/tools/skills/README.md
@@ -29,27 +29,110 @@ Both files contain the same instructions — only the frontmatter differs. Your 
 
 ### Kiro
 
-Paste the GitHub folder URL into Kiro's power installer:
+Open the **Agent Steering & Skills** panel, click **+** > **Import a skill** > **GitHub**, and paste:
 
 ```
 https://github.com/jcwolfaws/aws-graviton-getting-started/tree/main/tools/skills/languages/java-x86-to-graviton
 ```
 
-### Claude Code, Cursor, Codex, and other Agent Skills platforms
+### Cursor
 
-Copy the skill folder into your project:
+Open **Settings** (`Cmd+Shift+J` / `Ctrl+Shift+J`) > **Rules** > **Add Rule** > **Remote Rule (GitHub)** and paste:
 
-```bash
-cp -r tools/skills/languages/java-x86-to-graviton/ /path/to/your/project/.skills/java-x86-to-graviton/
+```
+https://github.com/jcwolfaws/aws-graviton-getting-started/tree/main/tools/skills/languages/java-x86-to-graviton
 ```
 
-Your AI coding assistant will detect the `SKILL.md` and follow the instructions when triggered.
+### Claude Code
 
-### Direct reference
+```bash
+git clone --filter=blob:none --sparse https://github.com/jcwolfaws/aws-graviton-getting-started.git /tmp/graviton-skill && \
+  cd /tmp/graviton-skill && \
+  git sparse-checkout set tools/skills/languages/java-x86-to-graviton && \
+  cp -r tools/skills/languages/java-x86-to-graviton ~/.claude/skills/ && \
+  cd - && rm -rf /tmp/graviton-skill
+```
 
-You can also point your AI assistant to the skill without installing:
+### GitHub Copilot / VS Code
 
-> Analyze this Java project for Graviton migration using the skill at tools/skills/languages/java-x86-to-graviton/SKILL.md
+```bash
+git clone --filter=blob:none --sparse https://github.com/jcwolfaws/aws-graviton-getting-started.git /tmp/graviton-skill && \
+  cd /tmp/graviton-skill && \
+  git sparse-checkout set tools/skills/languages/java-x86-to-graviton && \
+  mkdir -p .github/skills && \
+  cp -r tools/skills/languages/java-x86-to-graviton .github/skills/ && \
+  cd - && rm -rf /tmp/graviton-skill
+```
+
+### OpenAI Codex
+
+```bash
+git clone --filter=blob:none --sparse https://github.com/jcwolfaws/aws-graviton-getting-started.git /tmp/graviton-skill && \
+  cd /tmp/graviton-skill && \
+  git sparse-checkout set tools/skills/languages/java-x86-to-graviton && \
+  mkdir -p ~/.codex/skills && \
+  cp -r tools/skills/languages/java-x86-to-graviton ~/.codex/skills/ && \
+  cd - && rm -rf /tmp/graviton-skill
+```
+
+### Windsurf
+
+```bash
+git clone --filter=blob:none --sparse https://github.com/jcwolfaws/aws-graviton-getting-started.git /tmp/graviton-skill && \
+  cd /tmp/graviton-skill && \
+  git sparse-checkout set tools/skills/languages/java-x86-to-graviton && \
+  mkdir -p .windsurf/skills && \
+  cp -r tools/skills/languages/java-x86-to-graviton .windsurf/skills/ && \
+  cd - && rm -rf /tmp/graviton-skill
+```
+
+### Gemini CLI
+
+```bash
+git clone --filter=blob:none --sparse https://github.com/jcwolfaws/aws-graviton-getting-started.git /tmp/graviton-skill && \
+  cd /tmp/graviton-skill && \
+  git sparse-checkout set tools/skills/languages/java-x86-to-graviton && \
+  mkdir -p ~/.gemini/skills && \
+  cp -r tools/skills/languages/java-x86-to-graviton ~/.gemini/skills/ && \
+  cd - && rm -rf /tmp/graviton-skill
+```
+
+### Roo Code
+
+```bash
+git clone --filter=blob:none --sparse https://github.com/jcwolfaws/aws-graviton-getting-started.git /tmp/graviton-skill && \
+  cd /tmp/graviton-skill && \
+  git sparse-checkout set tools/skills/languages/java-x86-to-graviton && \
+  mkdir -p .roo/skills && \
+  cp -r tools/skills/languages/java-x86-to-graviton .roo/skills/ && \
+  cd - && rm -rf /tmp/graviton-skill
+```
+
+### Goose
+
+```bash
+git clone --filter=blob:none --sparse https://github.com/jcwolfaws/aws-graviton-getting-started.git /tmp/graviton-skill && \
+  cd /tmp/graviton-skill && \
+  git sparse-checkout set tools/skills/languages/java-x86-to-graviton && \
+  mkdir -p ~/.config/goose/skills && \
+  cp -r tools/skills/languages/java-x86-to-graviton ~/.config/goose/skills/ && \
+  cd - && rm -rf /tmp/graviton-skill
+```
+
+### Any platform (project-level)
+
+Copy the skill folder into the cross-platform standard path:
+
+```bash
+git clone --filter=blob:none --sparse https://github.com/jcwolfaws/aws-graviton-getting-started.git /tmp/graviton-skill && \
+  cd /tmp/graviton-skill && \
+  git sparse-checkout set tools/skills/languages/java-x86-to-graviton && \
+  mkdir -p .agents/skills && \
+  cp -r tools/skills/languages/java-x86-to-graviton .agents/skills/ && \
+  cd - && rm -rf /tmp/graviton-skill
+```
+
+The `.agents/skills/` path is supported by all Agent Skills-compatible platforms.
 
 ## Skill Folder Structure
 

--- a/tools/skills/_templates/POWER.template.md
+++ b/tools/skills/_templates/POWER.template.md
@@ -1,0 +1,17 @@
+---
+name: graviton-{{LANGUAGE}}-optimization
+displayName: "Graviton {{LANGUAGE_DISPLAY}} Optimization"
+description: >
+  Identifies and resolves {{LANGUAGE}} compatibility and performance issues
+  when migrating workloads from x86_64 to AWS Graviton (ARM64/AArch64) processors.
+keywords:
+  - graviton
+  - arm64
+  - {{LANGUAGE}}
+  - migration
+  - aarch64
+author: "{{AUTHOR}}"
+---
+
+<!-- Body content should match SKILL.template.md exactly. -->
+<!-- Copy everything below the frontmatter from SKILL.template.md here. -->

--- a/tools/skills/_templates/SKILL.template.md
+++ b/tools/skills/_templates/SKILL.template.md
@@ -1,0 +1,79 @@
+---
+name: graviton-{{LANGUAGE}}-optimization
+description: >
+  Identifies and resolves {{LANGUAGE}} compatibility and performance issues
+  when migrating workloads from x86_64 to AWS Graviton (ARM64/AArch64) processors.
+triggers:
+  - graviton {{LANGUAGE}}
+  - {{LANGUAGE}} arm64
+  - {{LANGUAGE}} aarch64 migration
+tags:
+  - graviton
+  - arm64
+  - {{LANGUAGE}}
+  - migration
+  - performance
+---
+
+# Graviton {{LANGUAGE_DISPLAY}} Optimization
+
+## Goal
+
+Analyze a {{LANGUAGE_DISPLAY}} project and produce a migration/optimization plan
+for running on AWS Graviton (ARM64/AArch64) instances, covering:
+
+1. **Dependency audit** — identify x86-specific or incompatible dependencies
+2. **Build configuration** — ensure correct ARM64 compiler flags and targets
+3. **Runtime configuration** — optimal JVM flags, runtime settings, etc.
+4. **Performance validation** — benchmarks, profiling, and regression checks
+
+## Context
+
+AWS Graviton processors (Graviton2, Graviton3, Graviton4) are ARM64-based
+and deliver better price-performance for most workloads. However, migrating
+from x86_64 requires checking for:
+
+- Native/binary dependencies compiled for x86 only
+- Hardcoded architecture assumptions (e.g., SSE/AVX intrinsics)
+- Build toolchain and CI/CD pipeline updates
+- Language-specific runtime tuning for ARM64
+
+Reference: https://github.com/aws/aws-graviton-getting-started
+
+## Steps
+
+### 1. Scan the project
+
+- Identify the build system ({{BUILD_SYSTEMS}})
+- List all dependencies, flagging any with native/binary components
+- Check for architecture-specific code (inline assembly, SIMD intrinsics, etc.)
+
+### 2. Check dependency compatibility
+
+- For each native dependency, verify ARM64/AArch64 support
+- Flag dependencies with no ARM64 build available
+- Suggest alternatives where possible
+
+### 3. Update build configuration
+
+{{BUILD_CONFIG_INSTRUCTIONS}}
+
+### 4. Update runtime configuration
+
+{{RUNTIME_CONFIG_INSTRUCTIONS}}
+
+### 5. Validate
+
+- Build the project targeting `aarch64` / `arm64`
+- Run the full test suite
+- Compare performance metrics against x86_64 baseline
+- Check for correctness regressions (especially floating-point edge cases)
+
+### 6. Generate migration report
+
+Produce a summary with:
+- ✅ Compatible dependencies
+- ⚠️ Dependencies requiring updates
+- ❌ Blockers (no ARM64 support)
+- Recommended Graviton instance type (c7g, m7g, r7g, etc.)
+- Estimated performance delta (if benchmarks were run)

--- a/tools/skills/_templates/SKILL.template.md
+++ b/tools/skills/_templates/SKILL.template.md
@@ -68,5 +68,5 @@ Produce a summary with:
 - Compatible dependencies
 - Dependencies requiring updates
 - Blockers (no ARM64 support)
-- Recommended Graviton instance type (c7g, m7g, r7g, etc.)
+- Recommended Graviton instance type (c8g, m8g, r8g, etc.)
 - Estimated performance delta (if benchmarks were run)

--- a/tools/skills/_templates/SKILL.template.md
+++ b/tools/skills/_templates/SKILL.template.md
@@ -3,16 +3,9 @@ name: graviton-{{LANGUAGE}}-optimization
 description: >
   Identifies and resolves {{LANGUAGE}} compatibility and performance issues
   when migrating workloads from x86_64 to AWS Graviton (ARM64/AArch64) processors.
-triggers:
-  - graviton {{LANGUAGE}}
-  - {{LANGUAGE}} arm64
-  - {{LANGUAGE}} aarch64 migration
-tags:
-  - graviton
-  - arm64
-  - {{LANGUAGE}}
-  - migration
-  - performance
+metadata:
+  author: "{{AUTHOR}}"
+  version: "1.0"
 ---
 
 # Graviton {{LANGUAGE_DISPLAY}} Optimization
@@ -72,8 +65,8 @@ Reference: https://github.com/aws/aws-graviton-getting-started
 ### 6. Generate migration report
 
 Produce a summary with:
-- ✅ Compatible dependencies
-- ⚠️ Dependencies requiring updates
-- ❌ Blockers (no ARM64 support)
+- Compatible dependencies
+- Dependencies requiring updates
+- Blockers (no ARM64 support)
 - Recommended Graviton instance type (c7g, m7g, r7g, etc.)
 - Estimated performance delta (if benchmarks were run)

--- a/tools/skills/languages/java-x86-to-graviton/POWER.md
+++ b/tools/skills/languages/java-x86-to-graviton/POWER.md
@@ -1,0 +1,1 @@
+SKILL.md

--- a/tools/skills/languages/java-x86-to-graviton/POWER.md
+++ b/tools/skills/languages/java-x86-to-graviton/POWER.md
@@ -3,7 +3,7 @@ name: java-x86-to-graviton
 displayName: "Java x86 to Graviton Migration"
 description: "Validates Java application compatibility with AWS Graviton (ARM64) architecture by analyzing native libraries, dependencies (including transitive), and architecture-specific code. Performs static analysis, applies ARM64-required dependency updates, configures Graviton JVM flags, and validates builds on ARM64."
 keywords: ["java", "graviton", "arm64", "aarch64", "migration", "jvm", "native libraries", "dependencies"]
-author: "jcwolfaws"
+author: "AWS"
 ---
 
 # Java Application AWS Graviton (ARM64) Compatibility Validation

--- a/tools/skills/languages/java-x86-to-graviton/POWER.md
+++ b/tools/skills/languages/java-x86-to-graviton/POWER.md
@@ -1,1 +1,151 @@
-SKILL.md
+---
+name: java-x86-to-graviton
+displayName: "Java x86 to Graviton Migration"
+description: "Validates Java application compatibility with AWS Graviton (ARM64) architecture by analyzing native libraries, dependencies (including transitive), and architecture-specific code. Performs static analysis, applies ARM64-required dependency updates, configures Graviton JVM flags, and validates builds on ARM64."
+keywords: ["java", "graviton", "arm64", "aarch64", "migration", "jvm", "native libraries", "dependencies"]
+author: "jcwolfaws"
+---
+
+# Java Application AWS Graviton (ARM64) Compatibility Validation
+
+Validate a Java application's readiness to run on AWS Graviton instances. This transformation identifies architecture-specific incompatibilities, validates native library ARM64 support, updates only ARM64-blocking dependencies, and tests on ARM64.
+
+## Scope Guardrails
+
+**CRITICAL: Read [document_references/agent-scope-boundaries.md](document_references/agent-scope-boundaries.md) before starting.** This file contains the decision tree for every dependency analysis and prevents scope creep.
+
+**In scope:** Native library ARM64 binaries, ARM64-blocking dependency updates, architecture detection code, Graviton JVM flags, ARM64 build/test validation.
+
+**Out of scope:** Java version changes, JDK distribution changes, general dependency modernization, security updates, code refactoring, .gitignore/.dockerignore changes.
+
+## Entry Criteria
+
+1. Java application currently running on x86 architecture
+2. Source code and build scripts available
+3. Current Java version documented (JDK 8+)
+4. Build configs (Maven/Gradle, Dockerfiles if containerized)
+5. ARM64 build/test environment access (Graviton EC2 or ARM64 containers)
+6. Complete dependency list with current versions
+7. Existing test suite
+
+## Transformation Workflow
+
+### Version Control Setup
+
+Initialize git if not already present. Commit after each meaningful step for traceability and rollback.
+
+```bash
+# Initialize if no git repo exists (local only, no remote required)
+if [ ! -d ".git" ]; then
+  git init
+  git add -A
+  git commit -m "Initial commit - baseline before ARM64 transformation"
+fi
+```
+
+**Commit at each step that produces output or changes files.** Use `git add -A && git commit -m "<message>"` with descriptive messages. Typical commit points:
+
+1. After documentation setup (graviton-validation/ folder created)
+2. After Phase 1 static analysis complete (all analysis reports written)
+3. After native library resolution (Phase 2.1 - .so files updated)
+4. After dependency updates (Phase 2.2 - pom.xml/build.gradle changed)
+5. After architecture code updates (Phase 2.3 - Java source changed)
+6. After Dockerfile/build config updates (Phase 2.4)
+7. After JVM optimization config (Phase 2.5)
+8. After build validation (Phase 3.1 - build results documented)
+9. After final validation and summary (Phase 3.3 + 00-summary.md written)
+
+Not every project will have all steps (e.g., no Dockerfile changes for host-based deployments, no native library resolution if none found). Commit whenever files change, skip commits for steps that produced no changes.
+
+### Documentation Setup
+
+Before Phase 1, create the output structure. See [document_references/documentation-standards.md](document_references/documentation-standards.md) for required sections and templates.
+
+```bash
+mkdir -p graviton-validation/raw
+```
+
+Output files produced:
+
+| File | Phase | Purpose |
+|------|-------|---------|
+| `01-project-assessment.md` | 1.1, 1.5 | Project structure, deployment type, Java env |
+| `02-native-library-report.md` | 1.2, 2.1 | Native library findings and resolutions |
+| `03-dependency-compatibility-report.md` | 1.3, 2.2 | Per-dependency ARM64 verdicts |
+| `04-code-scan-findings.md` | 1.4, 2.3 | Architecture-specific code patterns |
+| `05-jvm-configuration.md` | 2.5 | Graviton JVM flags |
+| `06-build-test-results.md` | 3.0-3.3 | Build, test results, startup checks |
+| `raw/dependency-tree-full.txt` | 1.1 | Raw dependency tree |
+| `raw/dependency-tree-native.txt` | 1.3 | Filtered native-artifact tree |
+| `00-summary.md` | End | Executive summary and exit criteria |
+
+### Phase 1: Static Compatibility Analysis
+
+Analyze the project without making changes. See [phases/phase1-static-analysis.md](phases/phase1-static-analysis.md) for detailed steps.
+
+1. **1.1 Project Structure Analysis** - Deployment type, multi-module detection, dependency tree generation, component risk categorization
+2. **1.2 Native Library Validation** - Scan for .so files (bundled and runtime-extracted), apply tiered FAIL/WARN/PASS policy
+3. **1.3 Dependency ARM64 Compatibility** - Analyze full transitive tree, classify as MUST UPGRADE / RECOMMENDED / COMPATIBLE
+4. **1.4 Architecture-Specific Code Detection** - Find `os.arch` checks, JNI/JNA usage missing ARM64 handling
+5. **1.5 Java Version Check** - Document version and distribution (do NOT change either)
+
+### Phase 2: Compatibility Resolution
+
+Apply fixes for ARM64-blocking issues only. See [phases/phase2-resolution.md](phases/phase2-resolution.md) for detailed steps.
+
+1. **2.1 Native Library Resolution** - Cross-compile or obtain ARM64 .so files, update loading logic
+2. **2.2 Dependency Updates** - Update ONLY MUST UPGRADE dependencies (including transitive via dependencyManagement)
+3. **2.3 Architecture Code Updates** - Add `aarch64` handling to architecture detection code
+4. **2.4 Build Config Updates** - Add ARM64 Maven profile, Dockerfile `--platform` annotations (preserve current base images)
+5. **2.5 JVM Optimizations** - Apply version-gated Graviton JVM flags, validate with `java <flags> -version`
+
+### Phase 3: ARM64 Validation & Testing
+
+Build and test on ARM64. See [phases/phase3-validation.md](phases/phase3-validation.md) for detailed steps.
+
+1. **3.0 Build Environment Prep** - Java runtime alignment for annotation processor compatibility (session-scoped only)
+2. **3.1 Build Validation** - Full build, classify failures as INFRA/ARM64/PRE-EXISTING
+3. **3.2 Functional Testing** - Execute test suite, classify failures, determine final build
+4. **3.3 Startup Validation** - Verify application starts, JVM flags accepted, no crashes
+5. **Write 00-summary.md** - Consolidate exit criteria using template from documentation-standards.md
+
+## Exit Criteria
+
+### Must Pass
+1. Application compiles on ARM64 without errors
+2. Native libraries load on ARM64 (or fallbacks function)
+3. All MUST UPGRADE dependencies updated to ARM64-compatible versions
+4. No ARM64-specific runtime errors
+5. Container images build on ARM64 (if containerized)
+
+### Test Criteria
+6. Test suite executes on ARM64
+7. Failures classified: `INFRA` (non-blocking) / `ARM64` (blocking) / `PRE-EXISTING` (non-blocking)
+8. No ARM64-related test failures
+
+### Startup Criteria
+9. Application starts on ARM64 without crashes
+10. JVM flags accepted without errors
+
+### Documentation Criteria
+11. All files in `graviton-validation/` using canonical names from documentation-standards.md
+
+## Test Failure Handling
+
+Infrastructure failures (missing DB, Docker, env vars) are non-blocking. Classify and document them, then run the final build without tests:
+- Gradle: `./gradlew clean build -x test`
+- Maven: `mvn clean install -DskipTests`
+
+ARM64 failures are blocking. Do not skip tests; the failing build is the final build.
+
+## User Responsibility (Post-Transformation)
+
+- Performance benchmarking and load testing
+- Integration testing with external services
+- CI/CD pipeline configuration for ARM64 builds
+
+## Notes
+
+- ARM64 execution environment required for full validation. On x86, static analysis only.
+- Multi-module projects require analysis of all submodules and the full transitive dependency tree
+- Graviton instances perform best at higher CPU utilization (70%+ recommended for testing)

--- a/tools/skills/languages/java-x86-to-graviton/README.md
+++ b/tools/skills/languages/java-x86-to-graviton/README.md
@@ -17,7 +17,7 @@ The skill is scoped strictly to ARM64 compatibility. It will not upgrade Java ve
 Copy this folder into your Java project:
 
 ```bash
-cp -r tools/skills/languages/java/ /path/to/your/project/.skills/java-x86-to-graviton/
+cp -r tools/skills/languages/java-x86-to-graviton/ /path/to/your/project/.skills/java-x86-to-graviton/
 ```
 
 Then ask your AI assistant:

--- a/tools/skills/languages/java-x86-to-graviton/README.md
+++ b/tools/skills/languages/java-x86-to-graviton/README.md
@@ -1,0 +1,52 @@
+# Java x86-to-Graviton Migration Skill
+
+Validates Java application compatibility with AWS Graviton (ARM64) architecture and applies the minimum changes required to run on ARM64.
+
+## What it does
+
+This skill guides an AI coding assistant through a complete Java Graviton migration:
+
+1. **Static Analysis** — Scans for native libraries (.so files), architecture-specific code, and ARM64-incompatible dependencies (including transitives)
+2. **Compatibility Resolution** — Updates only ARM64-blocking dependencies, adds aarch64 code paths, configures Graviton JVM flags
+3. **Validation** — Builds and tests on ARM64, classifies failures, produces a structured migration report
+
+The skill is scoped strictly to ARM64 compatibility. It will not upgrade Java versions, modernize dependencies, or fix security issues — only what's required for Graviton.
+
+## Quick Start
+
+Copy this folder into your Java project:
+
+```bash
+cp -r tools/skills/languages/java/ /path/to/your/project/.skills/java-x86-to-graviton/
+```
+
+Then ask your AI assistant:
+
+> Run the java-x86-to-graviton skill on this project
+
+## Skill Files
+
+| File | Purpose |
+|------|---------|
+| [SKILL.md](SKILL.md) | Main entry point — scope, workflow, exit criteria |
+| [phases/phase1-static-analysis.md](phases/phase1-static-analysis.md) | Dependency audit, native library scanning, code analysis |
+| [phases/phase2-resolution.md](phases/phase2-resolution.md) | ARM64-blocking fixes, JVM flags, Dockerfile updates |
+| [phases/phase3-validation.md](phases/phase3-validation.md) | ARM64 build, test, startup validation |
+| [document_references/agent-scope-boundaries.md](document_references/agent-scope-boundaries.md) | Scope guardrails and decision tree |
+| [document_references/documentation-standards.md](document_references/documentation-standards.md) | Output file format and naming conventions |
+
+## Output
+
+The skill produces a `graviton-validation/` folder in the project root with structured reports:
+
+- `00-summary.md` — Executive summary and exit criteria checklist
+- `01-project-assessment.md` — Project structure and Java environment
+- `02-native-library-report.md` — Native library findings and resolutions
+- `03-dependency-compatibility-report.md` — Per-dependency ARM64 verdicts
+- `04-code-scan-findings.md` — Architecture-specific code patterns
+- `05-jvm-configuration.md` — Graviton JVM flags
+- `06-build-test-results.md` — Build and test results
+
+## Related
+
+- [Java on Graviton guide](../../../../java.md) — The upstream Graviton Java documentation this skill draws from

--- a/tools/skills/languages/java-x86-to-graviton/SKILL.md
+++ b/tools/skills/languages/java-x86-to-graviton/SKILL.md
@@ -2,7 +2,7 @@
 name: java-x86-to-graviton
 description: Validates Java application compatibility with AWS Graviton (ARM64) architecture by analyzing native libraries, dependencies (including transitive), and architecture-specific code. Performs static analysis, applies ARM64-required dependency updates, configures Graviton JVM flags, and validates builds on ARM64. Use when migrating Java workloads from x86 to Graviton, validating ARM64 readiness, or running AWS Transform Custom java-x86-to-graviton transformations.
 metadata:
-  author: jcwolfaws
+  author: AWS
   version: "1.0"
 ---
 

--- a/tools/skills/languages/java-x86-to-graviton/SKILL.md
+++ b/tools/skills/languages/java-x86-to-graviton/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: java-x86-to-graviton
 description: Validates Java application compatibility with AWS Graviton (ARM64) architecture by analyzing native libraries, dependencies (including transitive), and architecture-specific code. Performs static analysis, applies ARM64-required dependency updates, configures Graviton JVM flags, and validates builds on ARM64. Use when migrating Java workloads from x86 to Graviton, validating ARM64 readiness, or running AWS Transform Custom java-x86-to-graviton transformations.
+metadata:
+  author: jcwolfaws
+  version: "1.0"
 ---
 
 # Java Application AWS Graviton (ARM64) Compatibility Validation

--- a/tools/skills/languages/java-x86-to-graviton/SKILL.md
+++ b/tools/skills/languages/java-x86-to-graviton/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: java-x86-to-graviton
+description: Validates Java application compatibility with AWS Graviton (ARM64) architecture by analyzing native libraries, dependencies (including transitive), and architecture-specific code. Performs static analysis, applies ARM64-required dependency updates, configures Graviton JVM flags, and validates builds on ARM64. Use when migrating Java workloads from x86 to Graviton, validating ARM64 readiness, or running AWS Transform Custom java-x86-to-graviton transformations.
+---
+
+# Java Application AWS Graviton (ARM64) Compatibility Validation
+
+Validate a Java application's readiness to run on AWS Graviton instances. This transformation identifies architecture-specific incompatibilities, validates native library ARM64 support, updates only ARM64-blocking dependencies, and tests on ARM64.
+
+## Scope Guardrails
+
+**CRITICAL: Read [document_references/agent-scope-boundaries.md](document_references/agent-scope-boundaries.md) before starting.** This file contains the decision tree for every dependency analysis and prevents scope creep.
+
+**In scope:** Native library ARM64 binaries, ARM64-blocking dependency updates, architecture detection code, Graviton JVM flags, ARM64 build/test validation.
+
+**Out of scope:** Java version changes, JDK distribution changes, general dependency modernization, security updates, code refactoring, .gitignore/.dockerignore changes.
+
+## Entry Criteria
+
+1. Java application currently running on x86 architecture
+2. Source code and build scripts available
+3. Current Java version documented (JDK 8+)
+4. Build configs (Maven/Gradle, Dockerfiles if containerized)
+5. ARM64 build/test environment access (Graviton EC2 or ARM64 containers)
+6. Complete dependency list with current versions
+7. Existing test suite
+
+## Transformation Workflow
+
+### Version Control Setup
+
+Initialize git if not already present. Commit after each meaningful step for traceability and rollback.
+
+```bash
+# Initialize if no git repo exists (local only, no remote required)
+if [ ! -d ".git" ]; then
+  git init
+  git add -A
+  git commit -m "Initial commit - baseline before ARM64 transformation"
+fi
+```
+
+**Commit at each step that produces output or changes files.** Use `git add -A && git commit -m "<message>"` with descriptive messages. Typical commit points:
+
+1. After documentation setup (graviton-validation/ folder created)
+2. After Phase 1 static analysis complete (all analysis reports written)
+3. After native library resolution (Phase 2.1 - .so files updated)
+4. After dependency updates (Phase 2.2 - pom.xml/build.gradle changed)
+5. After architecture code updates (Phase 2.3 - Java source changed)
+6. After Dockerfile/build config updates (Phase 2.4)
+7. After JVM optimization config (Phase 2.5)
+8. After build validation (Phase 3.1 - build results documented)
+9. After final validation and summary (Phase 3.3 + 00-summary.md written)
+
+Not every project will have all steps (e.g., no Dockerfile changes for host-based deployments, no native library resolution if none found). Commit whenever files change, skip commits for steps that produced no changes.
+
+### Documentation Setup
+
+Before Phase 1, create the output structure. See [document_references/documentation-standards.md](document_references/documentation-standards.md) for required sections and templates.
+
+```bash
+mkdir -p graviton-validation/raw
+```
+
+Output files produced:
+
+| File | Phase | Purpose |
+|------|-------|---------|
+| `01-project-assessment.md` | 1.1, 1.5 | Project structure, deployment type, Java env |
+| `02-native-library-report.md` | 1.2, 2.1 | Native library findings and resolutions |
+| `03-dependency-compatibility-report.md` | 1.3, 2.2 | Per-dependency ARM64 verdicts |
+| `04-code-scan-findings.md` | 1.4, 2.3 | Architecture-specific code patterns |
+| `05-jvm-configuration.md` | 2.5 | Graviton JVM flags |
+| `06-build-test-results.md` | 3.0-3.3 | Build, test results, startup checks |
+| `raw/dependency-tree-full.txt` | 1.1 | Raw dependency tree |
+| `raw/dependency-tree-native.txt` | 1.3 | Filtered native-artifact tree |
+| `00-summary.md` | End | Executive summary and exit criteria |
+
+### Phase 1: Static Compatibility Analysis
+
+Analyze the project without making changes. See [phases/phase1-static-analysis.md](phases/phase1-static-analysis.md) for detailed steps.
+
+1. **1.1 Project Structure Analysis** - Deployment type, multi-module detection, dependency tree generation, component risk categorization
+2. **1.2 Native Library Validation** - Scan for .so files (bundled and runtime-extracted), apply tiered FAIL/WARN/PASS policy
+3. **1.3 Dependency ARM64 Compatibility** - Analyze full transitive tree, classify as MUST UPGRADE / RECOMMENDED / COMPATIBLE
+4. **1.4 Architecture-Specific Code Detection** - Find `os.arch` checks, JNI/JNA usage missing ARM64 handling
+5. **1.5 Java Version Check** - Document version and distribution (do NOT change either)
+
+### Phase 2: Compatibility Resolution
+
+Apply fixes for ARM64-blocking issues only. See [phases/phase2-resolution.md](phases/phase2-resolution.md) for detailed steps.
+
+1. **2.1 Native Library Resolution** - Cross-compile or obtain ARM64 .so files, update loading logic
+2. **2.2 Dependency Updates** - Update ONLY MUST UPGRADE dependencies (including transitive via dependencyManagement)
+3. **2.3 Architecture Code Updates** - Add `aarch64` handling to architecture detection code
+4. **2.4 Build Config Updates** - Add ARM64 Maven profile, Dockerfile `--platform` annotations (preserve current base images)
+5. **2.5 JVM Optimizations** - Apply version-gated Graviton JVM flags, validate with `java <flags> -version`
+
+### Phase 3: ARM64 Validation & Testing
+
+Build and test on ARM64. See [phases/phase3-validation.md](phases/phase3-validation.md) for detailed steps.
+
+1. **3.0 Build Environment Prep** - Java runtime alignment for annotation processor compatibility (session-scoped only)
+2. **3.1 Build Validation** - Full build, classify failures as INFRA/ARM64/PRE-EXISTING
+3. **3.2 Functional Testing** - Execute test suite, classify failures, determine final build
+4. **3.3 Startup Validation** - Verify application starts, JVM flags accepted, no crashes
+5. **Write 00-summary.md** - Consolidate exit criteria using template from documentation-standards.md
+
+## Exit Criteria
+
+### Must Pass
+1. Application compiles on ARM64 without errors
+2. Native libraries load on ARM64 (or fallbacks function)
+3. All MUST UPGRADE dependencies updated to ARM64-compatible versions
+4. No ARM64-specific runtime errors
+5. Container images build on ARM64 (if containerized)
+
+### Test Criteria
+6. Test suite executes on ARM64
+7. Failures classified: `INFRA` (non-blocking) / `ARM64` (blocking) / `PRE-EXISTING` (non-blocking)
+8. No ARM64-related test failures
+
+### Startup Criteria
+9. Application starts on ARM64 without crashes
+10. JVM flags accepted without errors
+
+### Documentation Criteria
+11. All files in `graviton-validation/` using canonical names from documentation-standards.md
+
+## Test Failure Handling
+
+Infrastructure failures (missing DB, Docker, env vars) are non-blocking. Classify and document them, then run the final build without tests:
+- Gradle: `./gradlew clean build -x test`
+- Maven: `mvn clean install -DskipTests`
+
+ARM64 failures are blocking. Do not skip tests; the failing build is the final build.
+
+## User Responsibility (Post-Transformation)
+
+- Performance benchmarking and load testing
+- Integration testing with external services
+- CI/CD pipeline configuration for ARM64 builds
+
+## Notes
+
+- ARM64 execution environment required for full validation. On x86, static analysis only.
+- Multi-module projects require analysis of all submodules and the full transitive dependency tree
+- Graviton instances perform best at higher CPU utilization (70%+ recommended for testing)

--- a/tools/skills/languages/java-x86-to-graviton/document_references/agent-scope-boundaries.md
+++ b/tools/skills/languages/java-x86-to-graviton/document_references/agent-scope-boundaries.md
@@ -1,0 +1,247 @@
+# ARM64 Transformation - Agent Scope Boundaries
+
+## 🎯 Primary Objective
+Validate Java application compatibility with AWS Graviton (ARM64) architecture.  
+**Focus ONLY on ARM64-specific compatibility issues.**
+
+## Quick Reference: ARM64 Dependency Update Decision Tree
+
+Use this decision tree for EVERY dependency analysis:
+
+```
+Is this dependency update required for ARM64 compatibility?
+│
+├─ Does the dependency contain native code (.so, .dll, .dylib)?
+│  ├─ YES → Does current version have ARM64 binaries?
+│  │  ├─ NO → ✅ MUST UPGRADE (ARM64 native libraries missing)
+│  │  └─ YES → ✅ COMPATIBLE (has ARM64 support)
+│  └─ NO (Pure Java) → ✅ COMPATIBLE (pure Java works on all architectures)
+│
+├─ Does current version FAIL to build on ARM64?
+│  ├─ YES → Check why:
+│  │  ├─ Missing ARM64 artifacts? → ✅ MUST UPGRADE
+│  │  ├─ Architecture detection issue? → ✅ MUST UPGRADE  
+│  │  └─ Other reason? → Investigate root cause
+│  └─ NO → Continue checking...
+│
+├─ Does current version FAIL to run on ARM64?
+│  ├─ YES → Check why:
+│  │  ├─ UnsatisfiedLinkError? → ✅ MUST UPGRADE (native lib issue)
+│  │  ├─ Documented ARM64 bug? → ✅ MUST UPGRADE
+│  │  └─ Other reason? → Investigate root cause
+│  └─ NO → Continue checking...
+│
+└─ Is the only reason "old version" or "best practice"?
+   └─ YES → ❌ OUT OF SCOPE (not an ARM64 issue)
+
+RESULT:
+- If no ARM64-specific issue found → Mark COMPATIBLE, do NOT upgrade
+- If ARM64-specific issue found → Document evidence and upgrade
+```
+
+**Quick Test Questions:**
+1. ❓ Will keeping this version cause ARM64 build to fail? 
+2. ❓ Will keeping this version cause ARM64 runtime to fail?
+3. ❓ Is there documented evidence of ARM64 incompatibility?
+
+If all answers are **NO** → **Do not upgrade** (out of scope)
+
+## ✅ IN SCOPE: What to Fix
+
+### 1. Native Library Issues
+- ✅ Dependencies with x86-only `.so`/`.dll`/`.dylib` files
+- ✅ Missing ARM64 native library artifacts
+- ✅ Example: JNA 5.6.0 → 5.8.0 (lacks ARM64 .so files)
+
+### 2. Build Tool Artifacts
+- ✅ Protoc compiler missing ARM64 executables
+- ✅ Build plugins missing ARM64 classifiers
+- ✅ Example: protoc 3.3.0 → 3.21.0 (no osx-aarch_64 artifact)
+
+### 3. Architecture Detection
+- ✅ Code checking for "amd64" without "aarch64" handling
+- ✅ Build plugins not detecting ARM64 architecture
+- ✅ Example: os-maven-plugin 1.4.1 → 1.7.0 (aarch64 detection)
+
+### 4. Documented ARM64 Bugs
+- ✅ Current version has known ARM64-specific runtime failures
+- ✅ Must have issue tracker evidence or release notes
+- ✅ Example: "Version X causes crash only on ARM64"
+
+## ❌ OUT OF SCOPE: What NOT to Fix
+
+### 1. General Dependency Modernization
+- ❌ "This version is old" → NOT an ARM64 issue
+- ❌ "We should use latest" → NOT an ARM64 issue
+- ❌ "Deprecated library" → NOT an ARM64 issue
+- ❌ Example: JUnit 3.8.1 → 4.13.2 (pure Java, works on ARM64)
+
+### 2. Security Updates
+- ❌ CVE fixes or vulnerability patches
+- ❌ Example: Log4j 1.2.17 → 2.20.0 (security, not ARM64)
+
+### 3. Feature Upgrades
+- ❌ Newer features or better performance
+- ❌ API modernization
+- ❌ Example: Spring 4.x → 5.x (features, not ARM64)
+
+### 4. Java Version Changes
+- ❌ Java 8 → 11 or Java 11 → 17 upgrades
+- ❌ JDK distribution changes (OpenJDK → Corretto)
+- ❌ Exception: Session-scoped Java switching for build tooling compatibility
+
+### 5. Code Refactoring
+- ❌ Code quality improvements
+- ❌ Design pattern changes
+- ❌ Performance optimizations (except Graviton-specific JVM flags)
+
+## 🔍 Decision Tree: Should I Update This Dependency?
+
+```
+For each dependency, ask in order:
+
+1. Does it contain native code?
+   NO → Mark COMPATIBLE, do NOT update
+   YES → Continue to #2
+
+2. Does current version have ARM64 binaries?
+   YES → Mark COMPATIBLE, do NOT update
+   NO → Continue to #3
+
+3. Will build FAIL on ARM64 without update?
+   NO → Mark COMPATIBLE, do NOT update
+   YES → MUST UPGRADE (document evidence)
+
+4. Will runtime FAIL on ARM64 without update?
+   NO → Mark COMPATIBLE, do NOT update
+   YES → MUST UPGRADE (document evidence)
+```
+
+**Simple Rule:** If it builds and runs on ARM64 today → **DO NOT UPDATE**
+
+## 📋 Common Pure Java Libraries (Always ARM64-Compatible)
+
+These are **almost always** ARM64-compatible without updates:
+
+**Testing Frameworks:**
+- JUnit (any version - even 3.8.1 from 2004)
+- TestNG
+- Mockito  
+- Hamcrest
+- AssertJ
+
+**Logging:**
+- Log4j 1.x and 2.x
+- SLF4J
+- Logback
+- Commons-Logging
+
+**Utilities:**
+- Commons-Lang
+- Commons-Collections
+- Commons-IO
+- Guava
+
+**Serialization:**
+- Jackson
+- Gson
+- JAXB
+
+**HTTP Clients (Pure Java):**
+- Apache HttpClient
+- OkHttp (Java parts)
+
+## 🚫 Red Flags: When Agent is Going Off-Scope
+
+**Stop immediately if you see:**
+- ❌ "This version is from [old year], should update"
+- ❌ "Security vulnerability CVE-XXXX-YYYY"
+- ❌ "Best practice to use latest version"
+- ❌ "Deprecated API, should modernize"
+- ❌ "Better performance in newer version"
+- ❌ "More features in latest release"
+
+**Correct responses:**
+- ✅ "Version X lacks linux-aarch_64 artifact"
+- ✅ "UnsatisfiedLinkError on ARM64 with version X"
+- ✅ "Build fails on ARM64: missing native library"
+- ✅ "Documented ARM64 crash in issue #XXXX"
+
+## ✅ How to Document Scope Compliance
+
+### For Updates Made:
+```markdown
+## ARM64-Required Dependency Updates
+
+| Dependency | Old → New | ARM64 Issue | Evidence |
+|------------|-----------|-------------|----------|
+| protoc | 3.3.0 → 3.21.0 | Missing osx-aarch_64 artifact | Build log shows "Could not find artifact" |
+| JNA | 5.6.0 → 5.8.0 | Missing ARM64 .so files | Runtime UnsatisfiedLinkError on ARM64 |
+```
+
+### For Updates NOT Made:
+```markdown
+## Dependencies Validated as ARM64-Compatible (No Updates)
+
+| Dependency | Version | Status | Notes |
+|------------|---------|--------|-------|
+| JUnit | 3.8.1 | ✅ Compatible | Pure Java, works on ARM64. Modernization out of scope. |
+| Log4j | 1.2.17 | ✅ Compatible | Pure Java, no ARM64 issues. Security updates out of scope. |
+| Commons-Lang | 2.6 | ✅ Compatible | Pure Java library, fully ARM64-compatible. |
+```
+
+## 🎓 Learning from Past Mistakes
+
+### Case Study: JUnit 3.8.1
+
+**Initial Analysis (WRONG):**
+> "JUnit 3.8.1 is from 2004, mark as MUST UPGRADE for modern Java compatibility"
+
+**Why This Was Wrong:**
+- JUnit 3.8.1 is pure Java (no native code)
+- It builds successfully on ARM64
+- It runs successfully on ARM64 with Java 17
+- Being "old" is NOT an ARM64 compatibility issue
+
+**Correct Analysis:**
+> "JUnit 3.8.1: Pure Java library, no native dependencies, builds and runs successfully on ARM64. Status: COMPATIBLE. No update required for ARM64 compatibility. Note for user: Consider upgrading to JUnit 4/5 as part of separate modernization effort."
+
+### Case Study: Protoc 3.3.0
+
+**Analysis (CORRECT):**
+> "Protoc 3.3.0 lacks osx-aarch_64 and linux-aarch_64 artifacts in Maven Central. Build will fail on ARM64 with 'Could not resolve artifact' error. MUST UPGRADE to 3.21.0+ which includes ARM64 executables."
+
+**Why This Was Correct:**
+- Specific ARM64 artifact missing
+- Build WILL fail on ARM64
+- Evidence-based reasoning
+- Clear minimum version requirement
+
+## 🎯 Success Criteria
+
+**Transformation is successful when:**
+1. ✅ Application builds on ARM64 without errors
+2. ✅ Application runs on ARM64 without crashes
+3. ✅ All tests pass on ARM64
+4. ✅ Only ARM64-specific issues were addressed
+5. ✅ No scope creep into general modernization
+
+**Transformation has scope creep if:**
+1. ❌ Updated dependencies that already worked on ARM64
+2. ❌ Fixed security issues unrelated to ARM64
+3. ❌ Modernized code for "best practices"
+4. ❌ Upgraded Java version unnecessarily
+5. ❌ Refactored working code
+
+## 📞 When in Doubt
+
+**Ask yourself:**
+- "If I don't make this change, will ARM64 build/runtime fail?"
+- "Is there concrete evidence this current version breaks on ARM64?"
+- "Am I updating this because it's old, or because ARM64 requires it?"
+
+**If unsure:** Mark as COMPATIBLE and document reasoning. It's better to under-fix than to introduce unnecessary scope creep.
+
+---
+
+**Remember:** This is an ARM64 compatibility validation, not a general dependency modernization project. Stay focused on ARM64-specific issues only.

--- a/tools/skills/languages/java-x86-to-graviton/document_references/agent-scope-boundaries.md
+++ b/tools/skills/languages/java-x86-to-graviton/document_references/agent-scope-boundaries.md
@@ -175,7 +175,7 @@ These are **almost always** ARM64-compatible without updates:
 
 | Dependency | Old → New | ARM64 Issue | Evidence |
 |------------|-----------|-------------|----------|
-| protoc | 3.3.0 → 3.21.0 | Missing osx-aarch_64 artifact | Build log shows "Could not find artifact" |
+| protoc | 3.3.0 → 3.21.0 | Missing linux-aarch_64 and osx-aarch_64 artifacts | Build log shows "Could not find artifact" |
 | JNA | 5.6.0 → 5.8.0 | Missing ARM64 .so files | Runtime UnsatisfiedLinkError on ARM64 |
 ```
 

--- a/tools/skills/languages/java-x86-to-graviton/document_references/documentation-standards.md
+++ b/tools/skills/languages/java-x86-to-graviton/document_references/documentation-standards.md
@@ -1,0 +1,324 @@
+# ARM64 Transformation — Documentation Standards
+
+## Purpose
+This document defines the standard output folder structure, canonical filenames, and content requirements for all documentation produced during an ARM64 Graviton compatibility transformation. Adherence to this standard ensures consistency across transformation runs regardless of which agent executes the work.
+
+## Output Folder Structure
+
+All transformation output documents MUST be written to a single folder named `graviton-validation/` in the project root. The agent MUST create this folder and its `raw/` subfolder at the start of Phase 1 before any analysis begins.
+
+```
+<project-root>/
+└── graviton-validation/
+    ├── 00-summary.md                        # Final roll-up of all findings and exit criteria
+    ├── 01-project-assessment.md             # Project structure, deployment type, Java environment
+    ├── 02-native-library-report.md          # All .so / native library findings and resolutions
+    ├── 03-dependency-compatibility-report.md # Per-dependency ARM64 compatibility verdicts
+    ├── 04-code-scan-findings.md             # Architecture-specific code patterns detected
+    ├── 05-jvm-configuration.md              # Graviton-optimized JVM flags and profiles
+    ├── 06-build-test-results.md             # Build validation, test results, failure classification
+    └── raw/                                 # Machine-generated artifacts (not hand-authored)
+        ├── dependency-tree-full.txt         # Full dependency tree output
+        └── dependency-tree-native.txt       # Filtered tree (native-code artifacts only)
+```
+
+## Agent Instructions
+
+1. **Create `graviton-validation/` and `graviton-validation/raw/` at the start of Phase 1.** This is the first action before any analysis.
+2. **Use EXACTLY these filenames.** Do not rename, renumber, or create additional top-level files.
+3. **Write to each file progressively** as the corresponding phase completes. Do not wait until the end to produce all documentation.
+4. **Raw files go in `raw/`.** Only machine-generated command output belongs in `raw/`. Do not put authored content there.
+5. **`00-summary.md` is written last**, after all other files are complete. It references (not duplicates) the detail in files 01–06.
+6. **If a section has no findings**, include the section header with an explicit "No findings" statement. Do not omit empty sections — their absence is ambiguous.
+7. **Do not create documentation files outside `graviton-validation/`.** All transformation documentation lives in this single folder.
+
+---
+
+## File Specifications
+
+### `00-summary.md` — Transformation Summary
+
+**Created:** End of transformation (Phase 3 complete)
+**Purpose:** Single-page executive summary mapping to all exit criteria. This is the first file a reviewer reads.
+
+**Required sections:**
+```markdown
+# ARM64 Compatibility Validation — Summary
+
+## Project Overview
+- **Project Name:** <n>
+- **Deployment Type:** Containerized | Host-based | Both
+- **Java Version:** <version>
+- **JDK Distribution:** <distribution>
+- **Build Tool:** Maven <version> | Gradle <version>
+- **Multi-Module:** Yes (N modules) | No
+- **Date:** <ISO 8601>
+
+## Exit Criteria Checklist
+| # | Criterion | Status | Notes |
+|---|-----------|--------|-------|
+| 1 | Compiles on ARM64 without errors | ✅ PASS / ❌ FAIL | |
+| 2 | Native libraries load on ARM64 | ✅ PASS / ❌ FAIL | |
+| 3 | Blocking dependency updates applied | ✅ PASS / ❌ FAIL | |
+| 4 | No ARM64-specific runtime errors | ✅ PASS / ❌ FAIL | |
+| 5 | Container image builds on ARM64 | ✅ PASS / ❌ FAIL / N/A | |
+| 6 | Test suite executes on ARM64 | ✅ PASS / ❌ FAIL | |
+| 7 | No ARM64-related test failures | ✅ PASS / ❌ FAIL | |
+| 8 | Application starts on ARM64 | ✅ PASS / ❌ FAIL | |
+| 9 | JVM flags accepted without errors | ✅ PASS / ❌ FAIL | |
+
+## Changes Made
+<Brief summary of dependency updates, native library resolutions, code changes.
+Reference detail files: 02-native-library-report.md, 03-dependency-compatibility-report.md, 04-code-scan-findings.md>
+
+## Remaining Concerns
+<Any unresolved issues, user-responsibility items, or known limitations>
+```
+
+---
+
+### `01-project-assessment.md` — Project & Environment Assessment
+
+**Created:** Phase 1.1 and Phase 1.5
+**Purpose:** Records the baseline project state before any changes.
+
+**Required sections:**
+```markdown
+# Project Assessment
+
+## Deployment Type
+<Containerized | Host-based | Both>
+<Evidence: e.g., "Dockerfile found at ./Dockerfile", "systemd unit at ./deploy/app.service">
+
+## Project Structure
+- **Build Tool:** Maven | Gradle
+- **Multi-Module:** Yes | No
+- **Submodules:** <list if applicable>
+
+## Java Environment
+- **Java Version:** <exact version, e.g., 17.0.8>
+- **JDK Distribution:** <e.g., Eclipse Temurin, Amazon Corretto, OpenJDK>
+- **ARM64 Support Status:** Supported | Supported with limitations
+- **Known Graviton Issues:** None | <description>
+
+## Component Risk Categorization
+| Component | Risk Level | Rationale |
+|-----------|-----------|-----------|
+| <component> | CRITICAL / HIGH / MEDIUM / LOW | <why> |
+```
+
+---
+
+### `02-native-library-report.md` — Native Library Analysis & Resolution
+
+**Created:** Phase 1.2 (analysis), updated in Phase 2.1 (resolution)
+**Purpose:** Documents every native library found — bundled and runtime-extracted — its architecture, and how it was resolved.
+
+**Required sections:**
+```markdown
+# Native Library Report
+
+## Statically Bundled Libraries
+| Library | Source JAR/Location | Architecture | Verdict | Resolution |
+|---------|-------------------|--------------|---------|------------|
+| libfoo.so | commons-crypto-1.1.0.jar | x86_64 only | FAIL | Upgraded to 1.2.0 (includes aarch64) |
+| libbar.so | app-native/lib/ | ARM aarch64 | PASS | No action needed |
+
+## Runtime-Extracted Libraries
+| Dependency | Artifact | Extracts Native Code | ARM64 Support in Current Version | Verdict | Resolution |
+|------------|----------|---------------------|----------------------------------|---------|------------|
+| netty-transport-native-epoll | 4.1.68.Final | Yes | Yes (linux-aarch_64 classifier) | PASS | No action needed |
+| snappy-java | 1.1.7.3 | Yes | No (x86_64 only) | FAIL | Upgraded to 1.1.10.5 |
+
+## Resolution Details
+<For each FAIL or WARN, describe the resolution approach>
+
+## Pure Java Fallbacks Documented
+<List any libraries where a pure Java fallback path was chosen instead of native resolution>
+
+## No Findings
+<If no native libraries were detected, state explicitly:>
+No native libraries (bundled or runtime-extracted) detected. All dependencies are pure Java.
+```
+
+---
+
+### `03-dependency-compatibility-report.md` — Dependency ARM64 Compatibility
+
+**Created:** Phase 1.3 (analysis), updated in Phase 2.2 (resolution)
+**Purpose:** The primary dependency-by-dependency compatibility assessment.
+
+**Required sections:**
+```markdown
+# Dependency ARM64 Compatibility Report
+
+## MUST UPGRADE (Blocking)
+| Dependency | Current Version | Minimum ARM64 Version | Applied Version | ARM64 Issue | Evidence |
+|------------|----------------|----------------------|-----------------|-------------|----------|
+| net.java.dev.jna:jna | 5.6.0 | 5.8.0 | 5.14.0 | Missing ARM64 .so | UnsatisfiedLinkError on aarch64 |
+
+## RECOMMENDED UPGRADE (Non-Blocking)
+| Dependency | Current Version | Recommended Version | Reason | Action Taken |
+|------------|----------------|--------------------|---------|----|
+| <dep> | <ver> | <ver> | ARM64 perf improvement | Documented for user |
+
+## COMPATIBLE (No Action Needed)
+| Dependency | Version | Basis |
+|------------|---------|-------|
+| junit:junit | 3.8.1 | Pure Java — no native code |
+| com.google.guava:guava | 31.1-jre | Pure Java — no native code |
+
+## Transitive Dependency Resolutions
+| Transitive Dependency | Pulled In By | Issue | Resolution Method |
+|-----------------------|-------------|-------|-------------------|
+| org.xerial.snappy:snappy-java 1.1.7.3 | kafka-clients 2.7.0 | No linux-aarch64 binary | dependencyManagement override to 1.1.10.5 |
+```
+
+---
+
+### `04-code-scan-findings.md` — Architecture-Specific Code Detection
+
+**Created:** Phase 1.4, updated in Phase 2.3 (resolution)
+**Purpose:** Records all source code locations with architecture-sensitive patterns and changes applied.
+
+**Required sections:**
+```markdown
+# Architecture-Specific Code Scan
+
+## Architecture Detection Patterns Found
+| File | Line(s) | Pattern | ARM64 Handling Present | Action Required |
+|------|---------|---------|----------------------|-----------------|
+| src/.../NativeLoader.java | 42-48 | System.getProperty("os.arch") | No — only checks "amd64" | Add "aarch64" branch |
+
+## JNI/JNA Usage
+| File | Line(s) | Type | Library | ARM64 Validated |
+|------|---------|------|---------|-----------------|
+| src/.../Bridge.java | 23 | JNA Native.load() | libbridge.so | Yes — aarch64 binary present |
+
+## Changes Applied
+<Summary of code changes made in Phase 2.3 to add ARM64 handling>
+
+## No Findings
+<If no architecture-specific code was detected, state explicitly:>
+No architecture-specific code patterns, JNI, or JNA usage detected. All code is pure Java.
+```
+
+---
+
+### `05-jvm-configuration.md` — Graviton JVM Optimization
+
+**Created:** Phase 2.5
+**Purpose:** Records the JVM flags applied, version-gated rationale, and validation results.
+
+**Required sections:**
+```markdown
+# Graviton JVM Configuration
+
+## Target Java Version
+<JDK version used for flag selection, e.g., JDK 17>
+
+## Applied JVM Flags
+| Flag | Applicable JDK Versions | Workload Type | Expected Impact |
+|------|------------------------|---------------|-----------------|
+| -XX:-TieredCompilation | 11, 17, 21+ | Moderate lock contention | Reduced compilation overhead |
+
+## Flags NOT Applied (Version-Gated)
+| Flag | Reason Not Applied |
+|------|--------------------|
+| -XX:CompilationMode=high-only | Removed in JDK 21+; project uses JDK 21 |
+
+## Flag Validation
+<Output of: java <flags> -version>
+<Confirm all flags accepted without errors>
+
+## Configuration Profiles
+<If multiple profiles were created for different workload types, list them here>
+```
+
+---
+
+### `06-build-test-results.md` — Build & Test Validation Results
+
+**Created:** Phase 3.1, 3.2, 3.3
+**Purpose:** Records all build attempts, test execution results, failure classifications, and startup checks.
+
+**Required sections:**
+```markdown
+# Build & Test Validation Results
+
+## Build Environment
+- **Architecture:** <output of `uname -m`, should be aarch64>
+- **Java Runtime:** <output of `java -version`>
+- **Build Tool:** <Maven/Gradle version>
+- **Build Environment Notes:** <any Java runtime alignment applied per Phase 3.0>
+
+## Build Attempts
+| # | Command | Result | Notes |
+|---|---------|--------|-------|
+| 1 | `./gradlew clean build` | ❌ FAIL | 3 test failures — see classification below |
+| 2 | `./gradlew clean build -x test` | ✅ PASS | Compilation successful |
+
+## Test Failure Classification
+| Test | Class | Failure Type | Root Cause | Blocking |
+|------|-------|-------------|------------|----------|
+| testDbConnection | IntegrationTest | INFRA | PostgreSQL not available | No |
+| testNativeAccel | CryptoTest | ARM64 | UnsatisfiedLinkError | Yes |
+
+## Final Build (Scoring Basis)
+- **Command:** <the final build command>
+- **Result:** ✅ PASS / ❌ FAIL
+- **Rationale:** <why this is the scoring build>
+
+## Container Validation (if applicable)
+- **Build Command:** `docker build -t app:arm64 .`
+- **Result:** ✅ PASS / ❌ FAIL
+- **Architecture Verified:** `os.arch = aarch64`
+- **JDK Verified:** <matches original distribution and version>
+
+## Startup Validation
+- **Application starts without errors:** ✅ Yes | ❌ No
+- **JVM flags accepted:** ✅ Yes | ❌ No
+- **Runtime crashes:** None | <description>
+```
+
+---
+
+### `raw/dependency-tree-full.txt`
+
+**Created:** Phase 1.1 step 2
+**Purpose:** Raw output from `mvn dependency:tree` or `./gradlew dependencies`. Kept for traceability; not hand-edited.
+
+---
+
+### `raw/dependency-tree-native.txt`
+
+**Created:** Phase 1.3 step 1
+**Purpose:** Filtered dependency tree showing only known native-code artifacts. Kept for traceability; not hand-edited.
+
+---
+
+## Mapping: Transformation Steps → Output Files
+
+| # | Transformation Step | What Is Produced | Output File |
+|---|---|---|---|
+| 1 | 1.1 step 1 — Deployment type | Containerized vs host-based | `01-project-assessment.md` |
+| 2 | 1.1 step 2 — Dependency tree generation | Raw tree output | `raw/dependency-tree-full.txt` |
+| 3 | 1.1 step 4 — Component risk categorization | CRITICAL/HIGH/MEDIUM/LOW table | `01-project-assessment.md` |
+| 4 | 1.2.1 — Statically bundled .so scan | Architecture per .so file | `02-native-library-report.md` |
+| 5 | 1.2.2 — Runtime-extracted native detection | Libraries extracting native code | `02-native-library-report.md` |
+| 6 | 1.2.3 — Tiered validation verdicts | FAIL/WARN/PASS per library | `02-native-library-report.md` |
+| 7 | 1.2.3 step 3 — Recompilation requirements | Resolution notes | `02-native-library-report.md` |
+| 8 | 1.3 step 1 — Filtered transitive tree | Native-artifact-only tree | `raw/dependency-tree-native.txt` |
+| 9 | 1.3 step 3 — Compatibility report | MUST UPGRADE / RECOMMENDED / COMPATIBLE | `03-dependency-compatibility-report.md` |
+| 10 | 1.3 step 4 — Per-dependency findings | Detailed blocks per dependency | `03-dependency-compatibility-report.md` |
+| 11 | 1.4 — Code scan | Architecture patterns, JNI/JNA usage | `04-code-scan-findings.md` |
+| 12 | 1.5 — Java version & distribution | Version and distro record | `01-project-assessment.md` |
+| 13 | 2.1 — Native library resolution | Resolution per .so, fallback decisions | `02-native-library-report.md` |
+| 14 | 2.5 step 2 — JVM flag documentation | Flags, rationale, impact | `05-jvm-configuration.md` |
+| 15 | 2.5 step 3 — Config profiles | Workload-specific flag sets | `05-jvm-configuration.md` |
+| 16 | 3.0 — Annotation processor notes | Processor/version requiring alignment | `06-build-test-results.md` |
+| 17 | 3.0 — Blocker: no compatible JDK | Requirement documentation | `06-build-test-results.md` |
+| 18 | 3.1 — Build test classification | INFRA/ARM64/PRE-EXISTING per failure | `06-build-test-results.md` |
+| 19 | 3.2 — Functional test results | All test results, classification | `06-build-test-results.md` |
+| 20 | 3.3 — Startup validation | Start/flags/crash checks | `06-build-test-results.md` |
+| 21 | Exit — Summary | Roll-up of all findings and exit criteria | `00-summary.md` |

--- a/tools/skills/languages/java-x86-to-graviton/phases/phase1-static-analysis.md
+++ b/tools/skills/languages/java-x86-to-graviton/phases/phase1-static-analysis.md
@@ -1,0 +1,196 @@
+# Phase 1: Static Compatibility Analysis
+
+Analyze the project without making changes. All findings are documented in `graviton-validation/` files.
+
+## 1.1 Project Structure Analysis
+
+> **Output: `graviton-validation/01-project-assessment.md`** and **`graviton-validation/raw/dependency-tree-full.txt`**
+
+### Determine Deployment Type
+
+- Dockerfile or container config present: **Containerized**
+- systemd/init scripts or direct JAR/WAR: **Host-based**
+- Some applications support both
+
+### Detect Multi-Module Structure
+
+- Maven: parent POM with `<modules>` section
+- Gradle: `settings.gradle` / `settings.gradle.kts` with `include` directives
+- If multi-module: enumerate all submodules, analyze each independently
+- Native libraries may reside in child modules; do NOT limit to root build file
+
+### Generate Dependency Tree
+
+```bash
+# Maven
+mvn dependency:tree -DoutputType=text > graviton-validation/raw/dependency-tree-full.txt
+
+# Gradle
+./gradlew dependencies --configuration runtimeClasspath > graviton-validation/raw/dependency-tree-full.txt
+```
+
+### Categorize Components by Risk
+
+- **CRITICAL**: Native code (JNI/JNA), .so files, architecture-specific optimizations
+- **HIGH**: Dependencies with known x86-only versions, crypto libraries
+- **MEDIUM**: Build configs, deployment scripts, architecture detection code
+- **LOW**: Pure Java code without architecture dependencies
+
+## 1.2 Native Library Validation (.so File Analysis)
+
+> **Output: `graviton-validation/02-native-library-report.md`**
+
+Native libraries incompatible with ARM64 exist in two forms: **statically bundled** inside JARs and **dynamically extracted at runtime**. Both must be validated.
+
+### 1.2.1 Statically Bundled .so Scanning
+
+Scan all JARs for native libraries, including nested JARs in fat/uber JARs:
+
+```bash
+tmpdir=$(mktemp -d)
+trap "rm -rf $tmpdir" EXIT
+
+# Standard JARs
+for jar in $(find . -name "*.jar" -not -path "*/build/*" -not -path "*/target/*"); do
+  echo "=== Scanning: $jar ==="
+  unzip -l "$jar" 2>/dev/null | grep "\.so$"
+done
+
+# Spring Boot fat JARs (nested JARs in BOOT-INF/lib/)
+for jar in $(find . -name "*.jar" -not -path "*/build/*" -not -path "*/target/*"); do
+  nested=$(unzip -l "$jar" 2>/dev/null | grep "BOOT-INF/lib/.*\.jar$" | awk '{print $NF}')
+  if [ -n "$nested" ]; then
+    echo "=== Fat JAR detected: $jar ==="
+    unzip -q "$jar" -d "$tmpdir/fatjar" 2>/dev/null
+    for nested_jar in $(find "$tmpdir/fatjar/BOOT-INF/lib" -name "*.jar" 2>/dev/null); do
+      so_files=$(unzip -l "$nested_jar" 2>/dev/null | grep "\.so$")
+      if [ -n "$so_files" ]; then
+        echo "--- Nested JAR: $(basename $nested_jar) ---"
+        echo "$so_files"
+      fi
+    done
+    rm -rf "$tmpdir/fatjar"
+  fi
+done
+
+# Validate architecture of discovered .so files
+for jar in $(find . -name "*.jar" -not -path "*/build/*" -not -path "*/target/*"); do
+  unzip -q "$jar" -d "$tmpdir/extract" 2>/dev/null
+  find "$tmpdir/extract" -name "*.so" -exec file {} \;
+  rm -rf "$tmpdir/extract"
+done
+```
+
+**Fat/Uber JAR types:** Spring Boot fat JARs have native libs in `BOOT-INF/lib/`. Maven Shade and Gradle Shadow flatten into single JARs (standard scan covers them). WAR files: check `WEB-INF/lib/`.
+
+### 1.2.2 Runtime-Extracted Native Library Detection
+
+Some libraries extract native code at runtime rather than bundling .so files.
+
+```bash
+# Source code patterns
+grep -rn "Native.load\|Native.loadLibrary\|System.loadLibrary\|System.load(" \
+  --include="*.java" src/ || true
+
+grep -rn "jnr\.\|LibraryLoader" --include="*.java" src/ || true
+
+# Build file dependencies known to extract native code
+grep -n "netty-transport-native\|netty-tcnative\|io.grpc.*netty\|conscrypt\|jnr-ffi\|jnr-posix\|leveldbjni\|rocksdbjni\|sqlite-jdbc\|lz4-java\|zstd-jni\|snappy-java" \
+  pom.xml build.gradle build.gradle.kts 2>/dev/null || true
+```
+
+**Common runtime-extracting libraries:**
+- **Netty** (`netty-transport-native-epoll`, `netty-tcnative`): Extracts .so based on `os.arch`
+- **Conscrypt**: Native crypto libraries at runtime
+- **RocksDB** (`rocksdbjni`): Platform-specific .so at first use
+- **SQLite JDBC** (`sqlite-jdbc`): Bundles and extracts native SQLite
+- **LZ4/Zstd/Snappy** (`lz4-java`, `zstd-jni`, `snappy-java`): Native compression accelerators
+- **LevelDB** (`leveldbjni`): Native key-value store bindings
+
+For each: check if current version includes ARM64 binaries. If missing, flag as MUST UPGRADE. If pure Java fallback exists (e.g., Netty NIO vs native epoll), document it.
+
+### 1.2.3 Tiered Validation Policy
+
+**FAIL immediately if:**
+- .so shows x86-64 only AND no ARM64 version in JAR AND no source code available AND user cannot provide ARM64 version
+
+**WARN but proceed if:**
+- Multi-arch JAR with both x86 and ARM64, OR pure Java fallback exists, OR source available for recompilation
+
+**PASS if:**
+- .so shows "ARM aarch64" OR JAR contains .so in both `/linux/amd64/` and `/linux/aarch64/`
+
+For x86-only .so files: check for source in repo, document recompilation needs, or prompt user. Validate with:
+```bash
+file libname.so  # Must show "ARM aarch64"
+```
+
+## 1.3 Dependency ARM64 Compatibility Analysis
+
+> **Output: `graviton-validation/03-dependency-compatibility-report.md`** and **`graviton-validation/raw/dependency-tree-native.txt`**
+
+**IMPORTANT:** ARM64-incompatible native code can be introduced through transitive dependencies. A pure Java direct dependency may pull in a transitive with native code. Analyze the full tree.
+
+### Generate Filtered Tree
+
+```bash
+# Maven
+mvn dependency:tree -Dincludes=net.java.dev.jna,io.netty,org.xerial.snappy,org.lz4,com.github.luben,org.rocksdb,org.xerial,org.conscrypt,com.google.protobuf \
+  > graviton-validation/raw/dependency-tree-native.txt
+
+# Gradle
+./gradlew dependencies --configuration runtimeClasspath | grep -E "jna|netty-transport-native|snappy|lz4|zstd|rocksdb|sqlite|conscrypt|protobuf|jnr|leveldbjni" \
+  > graviton-validation/raw/dependency-tree-native.txt
+```
+
+### Classify Each Dependency
+
+**MUST UPGRADE (Blocking):** Current version lacks ARM64 binaries, contains x86-only native code, or has known critical ARM64 bugs.
+
+**RECOMMENDED UPGRADE (Non-blocking):** ARM64 works but has known performance issues or bug fixes in newer version.
+
+**COMPATIBLE (No action):** Full ARM64 support, no known issues, or pure Java with no architecture dependencies.
+
+For transitive dependencies: identify which direct dependency pulls it in. Resolution may require updating the parent.
+
+### Document Findings
+
+```
+Dependency: net.java.dev.jna:jna
+Current Version: 5.6.0
+Status: MUST UPGRADE
+Reason: Version 5.6.0 lacks ARM64 native libraries
+Minimum ARM64 Version: 5.8.0
+Recommended Version: 5.14.0
+
+Dependency: org.xerial.snappy:snappy-java (transitive via org.apache.kafka:kafka-clients)
+Current Version: 1.1.7.3
+Status: MUST UPGRADE
+Reason: Lacks linux-aarch64 native binary
+Minimum ARM64 Version: 1.1.8.1
+Resolution: dependencyManagement override or exclusion+re-add
+```
+
+## 1.4 Architecture-Specific Code Detection
+
+> **Output: `graviton-validation/04-code-scan-findings.md`**
+
+Scan for:
+```java
+System.getProperty("os.arch")
+System.getProperty("os.name")
+Native.load()
+System.loadLibrary()
+```
+
+Flag code that checks for "amd64" or "x86_64" without "aarch64" handling, loads native libraries without architecture-aware paths, or contains x86-specific assumptions.
+
+## 1.5 Java Version Compatibility Check
+
+> **Output: `graviton-validation/01-project-assessment.md`** (Java Environment section)
+
+1. Document current Java version AND JDK distribution (e.g., "OpenJDK 21", "Corretto 17")
+2. JDK 8: Supported with limitations. JDK 11+: Fully supported.
+3. Flag known Graviton compatibility issues
+4. **DO NOT change** the JDK distribution or Java version
+5. All major distributions support ARM64 for Java 8+

--- a/tools/skills/languages/java-x86-to-graviton/phases/phase2-resolution.md
+++ b/tools/skills/languages/java-x86-to-graviton/phases/phase2-resolution.md
@@ -13,8 +13,8 @@ For each x86-only .so identified in Phase 1:
 # Cross-compilation
 CC=aarch64-linux-gnu-gcc make
 
-# Or on ARM64 machine
-make CFLAGS="-march=armv8-a"
+# Or on ARM64 machine (distro defaults are correct for Graviton)
+make
 
 # Verify
 file libname.so  # Should show "ARM aarch64"
@@ -162,46 +162,20 @@ ENTRYPOINT ["java", "-jar", "app.jar"]
 
 Key: Builder stage uses `$BUILDPLATFORM`, runtime stage uses `$TARGETPLATFORM`. If original has no `--platform` annotations, add them. Host-based deployments skip Docker steps.
 
-## 2.5 Graviton-Specific JVM Optimizations
+## 2.5 Graviton-Specific JVM Recommendations
 
 > **Output: `graviton-validation/05-jvm-configuration.md`**
 
-Apply version-gated JVM flags. Not all flags are valid across JDK versions.
+Do NOT apply JVM flags automatically. Graviton runs well with default JVM settings. Document recommendations in the report for the team to evaluate during performance testing.
 
-**JDK 11:**
-```bash
--XX:-TieredCompilation
--XX:ReservedCodeCacheSize=64M
--XX:InitialCodeCacheSize=64M
--XX:+UnlockDiagnosticVMOptions -XX:+UseAESCTRIntrinsics  # crypto workloads
--Xss1m  # multi-threaded apps
-```
+**JDK 21+:** Most Graviton optimizations are already enabled by default (AES-CTR intrinsics, improved tiered compilation). No flags to recommend unless performance testing shows a specific issue.
 
-**JDK 17:**
-```bash
--XX:CICompilerCount=2
--XX:CompilationMode=high-only
--XX:-TieredCompilation
--XX:ReservedCodeCacheSize=64M
--XX:InitialCodeCacheSize=64M
--XX:+UnlockDiagnosticVMOptions -XX:+UseAESCTRIntrinsics  # crypto workloads
--Xss1m  # multi-threaded apps
-```
+**JDK 11-17:** Document the following as recommendations to try if performance testing shows a regression:
 
-**JDK 21+:**
-```bash
--XX:-TieredCompilation
--XX:ReservedCodeCacheSize=64M
--XX:InitialCodeCacheSize=64M
--Xss1m  # multi-threaded apps
-# UseAESCTRIntrinsics enabled by default in 21+
-# CompilationMode removed in some 21+ builds - test before applying
-```
+| Flag | Workload type | Notes |
+|------|---------------|-------|
+| `-XX:+UnlockDiagnosticVMOptions -XX:+UseAESCTRIntrinsics` | Crypto-heavy (TLS termination, encryption) | Enabled by default in 21+ |
+| `-XX:-TieredCompilation` | Long-running services (not latency-sensitive startup) | Trades startup time for steady-state throughput |
+| `-XX:ReservedCodeCacheSize=64M` | Large apps with many classes | Only if code cache pressure observed |
 
-**Always validate flags:**
-```bash
-java <flags> -version
-# Must exit without error
-```
-
-Document flag changes, expected impact, and create profiles for different workload types.
+The report should note the project's JDK version and which recommendations (if any) are relevant to its workload type.

--- a/tools/skills/languages/java-x86-to-graviton/phases/phase2-resolution.md
+++ b/tools/skills/languages/java-x86-to-graviton/phases/phase2-resolution.md
@@ -1,0 +1,207 @@
+# Phase 2: Compatibility Resolution
+
+Apply fixes for ARM64-blocking issues identified in Phase 1. Update ONLY what is required for ARM64 compatibility.
+
+## 2.1 Native Library Resolution
+
+> **Output: update `graviton-validation/02-native-library-report.md`** (Resolution Details, Pure Java Fallbacks)
+
+For each x86-only .so identified in Phase 1:
+
+**If source code available:**
+```bash
+# Cross-compilation
+CC=aarch64-linux-gnu-gcc make
+
+# Or on ARM64 machine
+make CFLAGS="-march=armv8-a"
+
+# Verify
+file libname.so  # Should show "ARM aarch64"
+```
+
+**If source unavailable:** Prompt user for ARM64-compatible version or confirm pure Java fallback.
+
+**Update native library loading logic** to handle ARM64:
+```java
+String arch = System.getProperty("os.arch");
+String libName;
+
+if ("aarch64".equals(arch)) {
+    libName = "libchatbot-arm64.so";
+} else if ("amd64".equals(arch) || "x86_64".equals(arch)) {
+    libName = "libchatbot-amd64.so";
+} else {
+    throw new UnsupportedOperationException("Unsupported architecture: " + arch);
+}
+
+try {
+    nativeLib = (NativeLib) Native.load(libName, NativeLib.class);
+} catch (UnsatisfiedLinkError e) {
+    logger.warn("Native library not available, using Java fallback", e);
+}
+```
+
+## 2.2 Dependency Compatibility Updates
+
+> **Output: update `graviton-validation/03-dependency-compatibility-report.md`**
+
+Update ONLY dependencies flagged as MUST UPGRADE. Do NOT upgrade compatible dependencies.
+
+**Direct dependencies (Maven):**
+```xml
+<dependency>
+    <groupId>net.java.dev.jna</groupId>
+    <artifactId>jna</artifactId>
+    <version>5.14.0</version> <!-- Minimum 5.8.0 for ARM64 -->
+</dependency>
+```
+
+**Transitive dependencies (Maven):**
+```xml
+<!-- Option A: dependencyManagement override -->
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>org.xerial.snappy</groupId>
+            <artifactId>snappy-java</artifactId>
+            <version>1.1.10.5</version>
+        </dependency>
+    </dependencies>
+</dependencyManagement>
+
+<!-- Option B: Exclude and re-add -->
+<dependency>
+    <groupId>org.apache.kafka</groupId>
+    <artifactId>kafka-clients</artifactId>
+    <version>${kafka.version}</version>
+    <exclusions>
+        <exclusion>
+            <groupId>org.xerial.snappy</groupId>
+            <artifactId>snappy-java</artifactId>
+        </exclusion>
+    </exclusions>
+</dependency>
+<dependency>
+    <groupId>org.xerial.snappy</groupId>
+    <artifactId>snappy-java</artifactId>
+    <version>1.1.10.5</version>
+</dependency>
+```
+
+**Transitive dependencies (Gradle):**
+```groovy
+configurations.all {
+    resolutionStrategy {
+        force 'org.xerial.snappy:snappy-java:1.1.10.5'
+    }
+}
+```
+
+## 2.3 Architecture Detection Code Updates
+
+> **Output: update `graviton-validation/04-code-scan-findings.md`** (Changes Applied)
+
+Add `aarch64` handling to all architecture detection:
+```java
+// Before
+if (System.getProperty("os.arch").equals("amd64")) {
+    // x86-specific code
+}
+
+// After
+String arch = System.getProperty("os.arch");
+if ("aarch64".equals(arch)) {
+    // ARM64-specific code path
+} else if ("amd64".equals(arch) || "x86_64".equals(arch)) {
+    // x86-specific code
+} else {
+    // Generic fallback
+}
+```
+
+## 2.4 Build Configuration Updates
+
+**Maven ARM64 profile:**
+```xml
+<profiles>
+    <profile>
+        <id>arm64</id>
+        <activation>
+            <os><arch>aarch64</arch></os>
+        </activation>
+        <properties>
+            <native.arch>aarch64</native.arch>
+        </properties>
+    </profile>
+</profiles>
+```
+
+**Dockerfile updates (containerized deployments only):**
+
+PRESERVE the current base image distribution and version. Do NOT change JDK distribution or version.
+
+Single-stage:
+```dockerfile
+FROM --platform=$BUILDPLATFORM <current-base-image>:<current-version>
+```
+
+Multi-stage:
+```dockerfile
+# Builder: BUILDPLATFORM for native build speed
+FROM --platform=$BUILDPLATFORM <current-builder-image>:<current-version> AS builder
+WORKDIR /app
+COPY . .
+RUN mvn clean package -DskipTests
+
+# Runtime: TARGETPLATFORM for ARM64 execution
+FROM --platform=$TARGETPLATFORM <current-runtime-image>:<current-version>
+COPY --from=builder /app/target/*.jar app.jar
+ENTRYPOINT ["java", "-jar", "app.jar"]
+```
+
+Key: Builder stage uses `$BUILDPLATFORM`, runtime stage uses `$TARGETPLATFORM`. If original has no `--platform` annotations, add them. Host-based deployments skip Docker steps.
+
+## 2.5 Graviton-Specific JVM Optimizations
+
+> **Output: `graviton-validation/05-jvm-configuration.md`**
+
+Apply version-gated JVM flags. Not all flags are valid across JDK versions.
+
+**JDK 11:**
+```bash
+-XX:-TieredCompilation
+-XX:ReservedCodeCacheSize=64M
+-XX:InitialCodeCacheSize=64M
+-XX:+UnlockDiagnosticVMOptions -XX:+UseAESCTRIntrinsics  # crypto workloads
+-Xss1m  # multi-threaded apps
+```
+
+**JDK 17:**
+```bash
+-XX:CICompilerCount=2
+-XX:CompilationMode=high-only
+-XX:-TieredCompilation
+-XX:ReservedCodeCacheSize=64M
+-XX:InitialCodeCacheSize=64M
+-XX:+UnlockDiagnosticVMOptions -XX:+UseAESCTRIntrinsics  # crypto workloads
+-Xss1m  # multi-threaded apps
+```
+
+**JDK 21+:**
+```bash
+-XX:-TieredCompilation
+-XX:ReservedCodeCacheSize=64M
+-XX:InitialCodeCacheSize=64M
+-Xss1m  # multi-threaded apps
+# UseAESCTRIntrinsics enabled by default in 21+
+# CompilationMode removed in some 21+ builds - test before applying
+```
+
+**Always validate flags:**
+```bash
+java <flags> -version
+# Must exit without error
+```
+
+Document flag changes, expected impact, and create profiles for different workload types.

--- a/tools/skills/languages/java-x86-to-graviton/phases/phase3-validation.md
+++ b/tools/skills/languages/java-x86-to-graviton/phases/phase3-validation.md
@@ -1,0 +1,226 @@
+# Phase 3: ARM64 Validation & Testing
+
+Build and test on ARM64 architecture. Supported platforms: Linux, macOS, WSL.
+
+## Container Runtime Detection
+
+Before skipping build validation, check for local container runtimes. Apple Silicon Macs run ARM64 containers natively via Docker or Finch, making full ARM64 validation possible without a remote Graviton instance.
+
+```bash
+# Detect available container runtimes
+CONTAINER_CMD=""
+if command -v finch &>/dev/null; then
+  CONTAINER_CMD="finch"
+elif command -v docker &>/dev/null; then
+  CONTAINER_CMD="docker"
+elif command -v nerdctl &>/dev/null; then
+  CONTAINER_CMD="nerdctl"
+elif command -v podman &>/dev/null; then
+  CONTAINER_CMD="podman"
+fi
+
+if [ -n "$CONTAINER_CMD" ]; then
+  echo "Container runtime found: $CONTAINER_CMD"
+else
+  echo "No container runtime found"
+fi
+
+# Check host architecture
+ARCH=$(uname -m)
+echo "Host architecture: $ARCH"
+```
+
+**Decision logic:**
+- **ARM64 host (aarch64/arm64) + container runtime:** Build and validate in containers using `$CONTAINER_CMD`. This is the ideal path.
+- **ARM64 host (aarch64/arm64) + no container runtime:** Build and validate directly on host.
+- **x86 host + container runtime with ARM64 support:** Use `--platform linux/arm64` to build and validate. Docker Desktop and Finch on Apple Silicon support this natively. On x86 Linux, `docker buildx` with QEMU emulation may work but is slower.
+- **x86 host + no container runtime:** Static analysis only. Document that ARM64 build validation requires an ARM64 environment and recommend the user run validation on a Graviton instance or ARM64 Mac.
+
+**Do NOT skip build validation if a container runtime is available.** Even on macOS, if Docker or Finch is installed, attempt the ARM64 container build. Only recommend external validation as a last resort when no container runtime is found.
+
+Throughout Phase 3, replace `docker` with `$CONTAINER_CMD` in all commands (e.g., `$CONTAINER_CMD build`, `$CONTAINER_CMD run`).
+
+## 3.0 Build Environment Preparation
+
+> **Output: `graviton-validation/06-build-test-results.md`** (Build Environment sections)
+
+### Java Runtime Alignment
+
+Build-time tools (annotation processors, compiler plugins) may not support the latest Java compiler versions. Runtime compatibility != compile-time tooling compatibility.
+
+**Common annotation processor sensitivities:**
+- **Lombok:** < 1.18.36 fails with Java 25
+- **MapStruct:** < 1.5.0 may fail with Java 17+
+- **Dagger:** < 2.40 may fail with Java 16+
+
+**If build fails with annotation processor errors:**
+1. Identify processor from `<annotationProcessorPaths>` or `annotationProcessor` in build files
+2. Check compatibility with current Java runtime
+3. Apply session-scoped Java alignment below
+4. Document the processor and version requiring alignment
+
+### Detect Project Target Version
+
+```bash
+# Maven
+PROJECT_TARGET=$(grep -oP '(?<=<release>)[0-9]+' pom.xml 2>/dev/null || \
+                 grep -oP '(?<=<target>)[0-9]+' pom.xml 2>/dev/null || \
+                 grep -oP '(?<=<java.version>)[0-9]+' pom.xml 2>/dev/null)
+
+# Gradle (Groovy)
+if [ -z "$PROJECT_TARGET" ]; then
+  PROJECT_TARGET=$(grep -oP 'sourceCompatibility\s*[=:]\s*['\''"]?\K[0-9]+' build.gradle 2>/dev/null || \
+                   grep -oP 'JavaVersion\.VERSION_\K[0-9]+' build.gradle 2>/dev/null || \
+                   grep -oP 'jvmToolchain\s*\(\s*\K[0-9]+' build.gradle 2>/dev/null)
+fi
+
+# Gradle (Kotlin DSL)
+if [ -z "$PROJECT_TARGET" ]; then
+  PROJECT_TARGET=$(grep -oP 'jvmToolchain\(\K[0-9]+' build.gradle.kts 2>/dev/null || \
+                   grep -oP 'languageVersion\.set\(JavaLanguageVersion\.of\(\K[0-9]+' build.gradle.kts 2>/dev/null)
+fi
+
+# gradle.properties fallback
+if [ -z "$PROJECT_TARGET" ]; then
+  PROJECT_TARGET=$(grep -oP 'javaVersion\s*=\s*\K[0-9]+' gradle.properties 2>/dev/null)
+fi
+
+echo "Project targets Java: $PROJECT_TARGET"
+```
+
+### Session-Scoped Java Switching
+
+If runtime significantly exceeds target (e.g., Java 25 with Java 17 target), use subshells:
+
+```bash
+# macOS
+(
+  export JAVA_HOME=$(/usr/libexec/java_home -v 21)
+  java -version
+  ${BUILD_CMD} clean install
+)
+
+# Linux
+JAVA_21_HOME=$(find /usr/lib/jvm /usr/java -maxdepth 1 -type d \( -name "*java-21*" -o -name "*jdk-21*" -o -name "*corretto-21*" \) 2>/dev/null | head -1)
+(
+  export JAVA_HOME="$JAVA_21_HOME"
+  export PATH="$JAVA_HOME/bin:$PATH"
+  java -version
+  ${BUILD_CMD} clean install
+)
+
+# SDKMAN
+(
+  source "$HOME/.sdkman/bin/sdkman-init.sh"
+  sdk use java 21.0.9-amzn
+  ${BUILD_CMD} clean install
+)
+
+# Single-command scope (any Unix)
+JAVA_HOME=/path/to/java-21 ${BUILD_CMD} clean install
+```
+
+**ALLOWED:** `export JAVA_HOME` in subshells `()`, single-command env, `bash -c`, SDKMAN `sdk use`.
+
+**FORBIDDEN:** Writing to `~/.zshrc`/`~/.bash_profile`/`~/.bashrc`, `update-alternatives --set`, `sdk default`, any persistent changes.
+
+**Version preference:** Java 21 > 17 > 11. After transformation, user's `java -version` must match pre-transformation.
+
+**If no compatible version found:** Document requirement, provide install commands, do NOT install automatically:
+```bash
+# Amazon Corretto
+# macOS: brew install --cask corretto@21
+# Amazon Linux/RHEL: sudo yum install java-21-amazon-corretto-devel
+# Ubuntu/Debian: see apt.corretto.aws setup
+```
+
+## 3.1 ARM64 Build Validation
+
+> **Output: `graviton-validation/06-build-test-results.md`** (Build Attempts, Test Failure Classification)
+
+### Build Strategy
+
+1. **First attempt** - full build with tests:
+   - Gradle: `./gradlew clean build`
+   - Maven: `mvn clean install`
+
+2. **If tests fail**, classify root cause:
+   - `INFRA` - Missing DB, Docker, env vars (non-blocking)
+   - `ARM64` - Architecture failure (blocking)
+   - `PRE-EXISTING` - Existed before migration (non-blocking)
+
+3. **INFRA or PRE-EXISTING failures:** Document, then build without tests:
+   - Gradle: `./gradlew clean build -x test`
+   - Maven: `mvn clean install -DskipTests`
+   - This becomes the **final build**
+
+4. **ARM64 failures:** Do NOT skip tests. Build fails, requires resolution.
+
+The final build command determines the build score.
+
+### Container Validation (if containerized)
+
+**Docker ENTRYPOINT handling:** Override entrypoint for validation commands.
+- Wrong: `$CONTAINER_CMD run app:arm64 java -version` (appends to entrypoint)
+- Correct: `$CONTAINER_CMD run --entrypoint java app:arm64 -version`
+
+```bash
+# Build
+$CONTAINER_CMD build --platform linux/arm64 -t app:arm64 .
+
+# Validate architecture
+$CONTAINER_CMD run --rm --platform linux/arm64 --entrypoint java app:arm64 -version
+$CONTAINER_CMD run --rm --platform linux/arm64 --entrypoint java app:arm64 -XshowSettings:properties -version 2>&1 | grep os.arch
+# Must show: os.arch = aarch64
+```
+
+Verify output shows the SAME JDK distribution and version as the original application.
+
+### Host-Based Validation
+
+```bash
+java -version  # Verify same distribution and version
+java -XshowSettings:properties -version | grep os.arch  # Must show aarch64
+
+./gradlew build  # or mvn clean package
+```
+
+## 3.2 Functional Testing on ARM64
+
+> **Output: update `graviton-validation/06-build-test-results.md`**
+
+**Containerized:**
+```bash
+$CONTAINER_CMD run --rm --platform linux/arm64 --entrypoint ./gradlew app:arm64 test
+# or
+$CONTAINER_CMD run --rm --platform linux/arm64 --entrypoint mvn app:arm64 test
+```
+
+**Host-based:**
+```bash
+./gradlew test  # or mvn test
+```
+
+Classify all failures (INFRA/ARM64/PRE-EXISTING). Test architecture-specific functionality: native library loading, crypto operations, file I/O, multi-threading.
+
+**Final build determination:**
+- All tests pass: test build is final build
+- INFRA/PRE-EXISTING failures: `./gradlew clean build -x test` or `mvn clean install -DskipTests`
+- ARM64 failures: failing build is final build (do not skip tests)
+
+## 3.3 Startup Validation
+
+> **Output: update `graviton-validation/06-build-test-results.md`** (Startup Validation)
+
+Verify:
+1. Application starts without errors
+2. JVM flags accepted without errors
+3. No immediate runtime crashes
+
+Recommend to user for independent testing: performance benchmarking, load testing, resource utilization measurement.
+
+## Write Summary
+
+> **Output: `graviton-validation/00-summary.md`**
+
+After all phases complete, write the summary using the template from [../document_references/documentation-standards.md](../document_references/documentation-standards.md). This file consolidates exit criteria status and references (not duplicates) detail in files 01-06.

--- a/tools/skills/languages/java-x86-to-graviton/summaries.md
+++ b/tools/skills/languages/java-x86-to-graviton/summaries.md
@@ -1,6 +1,8 @@
 # Skill File Index
 
-* "SKILL.md": "Main entry point. Contains scope guardrails, entry/exit criteria, transformation workflow overview with phase routing, test failure handling, and documentation output mapping. Read this first."
+* "SKILL.md": "Main entry point (Agent Skills format). Contains scope guardrails, entry/exit criteria, transformation workflow overview with phase routing, test failure handling, and documentation output mapping. Read this first."
+
+* "POWER.md": "Main entry point (Kiro format). Same content as SKILL.md with Kiro-specific frontmatter (displayName, keywords, author)."
 
 * "phases/phase1-static-analysis.md": "Detailed steps for Phase 1: project structure analysis, native library validation (bundled and runtime-extracted .so files), tiered FAIL/WARN/PASS policy, dependency ARM64 compatibility analysis including transitive dependencies, architecture-specific code detection, and Java version check."
 

--- a/tools/skills/languages/java-x86-to-graviton/summaries.md
+++ b/tools/skills/languages/java-x86-to-graviton/summaries.md
@@ -1,0 +1,13 @@
+# Skill File Index
+
+* "SKILL.md": "Main entry point. Contains scope guardrails, entry/exit criteria, transformation workflow overview with phase routing, test failure handling, and documentation output mapping. Read this first."
+
+* "phases/phase1-static-analysis.md": "Detailed steps for Phase 1: project structure analysis, native library validation (bundled and runtime-extracted .so files), tiered FAIL/WARN/PASS policy, dependency ARM64 compatibility analysis including transitive dependencies, architecture-specific code detection, and Java version check."
+
+* "phases/phase2-resolution.md": "Detailed steps for Phase 2: native library resolution (cross-compilation or fallback), dependency updates for MUST UPGRADE items only (Maven dependencyManagement and Gradle resolutionStrategy patterns for transitive deps), architecture detection code updates, Dockerfile platform annotations, and version-gated Graviton JVM flag configuration."
+
+* "phases/phase3-validation.md": "Detailed steps for Phase 3: Java runtime alignment for annotation processor compatibility (session-scoped only), build validation strategy with INFRA/ARM64/PRE-EXISTING failure classification, container and host-based validation, functional testing, startup checks, and summary generation."
+
+* "document_references/agent-scope-boundaries.md": "CRITICAL guardrails. Decision tree for every dependency analysis, IN SCOPE vs OUT OF SCOPE definitions, common pure Java libraries (always compatible), red flags for scope creep, and case studies (JUnit wrong vs Protoc correct). MUST be read before starting."
+
+* "document_references/documentation-standards.md": "Defines the mandatory graviton-validation/ output folder structure, canonical filenames (00-summary.md through 06-build-test-results.md plus raw/), required sections for each file, and mapping from transformation steps to output files. Read before Phase 1."


### PR DESCRIPTION
## Summary

Introduces a `tools/` directory as a home for developer tooling that complements the existing Graviton optimization guides. The first addition is **Agent Skills** - portable instruction packages that AI coding assistants can follow to perform Graviton migrations.

### What are Agent Skills?

[Agent Skills](https://agentskills.io) are an open standard for packaging expert knowledge into structured markdown that AI coding tools can consume. Each skill is a self-contained folder with instructions, phases, scope guardrails, and output templates. They work across 20+ platforms including Claude Code, Kiro, Cursor, Codex, Windsurf, Gemini CLI, GitHub Copilot, Roo Code, and Goose.

### What's included

**New files (tools/):**
- **`tools/README.md`** - Top-level entry point for the tools section
- **`tools/skills/README.md`** - Skill catalogue, platform compatibility table, install instructions for 10+ platforms, and guidance for creating new skills
- **`tools/skills/_templates/`** - Boilerplate templates for SKILL.md (Agent Skills spec) and POWER.md (Kiro format)
- **`tools/skills/languages/java-x86-to-graviton/`** - First complete skill: Java x86-to-Graviton migration

**Updated existing files:**
- **`README.md`** - Added "Tools and Agent Skills" to the table of contents and a new section before Additional Resources
- **`java.md`** - Added "Agent Skills for Java Migration" section at the end of the guide
- **`howtoresources.md`** - Added Agent Skills bullet under Development Tools

### The Java migration skill

A 3-phase workflow that guides an AI agent through:

1. **Static Analysis** - Scans for native libraries, architecture-specific code, and ARM64-incompatible dependencies (including transitives)
2. **Compatibility Resolution** - Updates only ARM64-blocking dependencies, adds aarch64 code paths, configures Graviton JVM flags
3. **Validation** - Builds and tests on ARM64, classifies failures, produces a structured migration report

Scoped strictly to ARM64 compatibility - won't upgrade Java versions, modernize dependencies, or fix security issues. Scope guardrails and a decision tree are included to prevent agent drift.

### Why this approach

The existing Graviton guides in this repo are written for humans. Agent Skills repackage that same expertise into a format optimized for AI assistants, so developers can point their tool at a Java project and get an automated, scoped Graviton migration. As more languages are added to the repo's guides, corresponding skills can follow the same pattern.

## Files changed

**13 new files (1830 lines):**
```
tools/
├── README.md
└── skills/
    ├── README.md
    ├── _templates/
    │   ├── POWER.template.md
    │   └── SKILL.template.md
    └── languages/
        └── java-x86-to-graviton/
            ├── POWER.md
            ├── README.md
            ├── SKILL.md
            ├── summaries.md
            ├── document_references/
            │   ├── agent-scope-boundaries.md
            │   └── documentation-standards.md
            └── phases/
                ├── phase1-static-analysis.md
                ├── phase2-resolution.md
                └── phase3-validation.md
```

**3 existing files updated:**
- `README.md` - TOC entry + new section
- `java.md` - closing section with skill link
- `howtoresources.md` - Development Tools bullet

## Test plan

- [x] Verify skill installs correctly on Claude Code (`cp` to `~/.claude/skills/`)
- [x] Verify skill imports via GitHub URL on Kiro and Cursor
- [x] Run the java-x86-to-graviton skill against a sample Java project on x86
- [x] Confirm generated `graviton-validation/` report matches documented output structure
- [x] Validate that scope guardrails prevent the agent from making out-of-scope changes
- [x] Verify cross-reference links in README.md, java.md, and howtoresources.md resolve correctly