### PR TITLE
update docs to reflect Graviton 4 support for SPE

### DIFF
--- a/perfrunbook/debug_hw_perf.md
+++ b/perfrunbook/debug_hw_perf.md
@@ -199,7 +199,7 @@ The SPE PMU on Graviton enables cores to precisely trace events for individual i
 linux `perf` tool.  It samples instructions from the executed instruction stream at random.  It is particularly useful for finding information
 about particular loads that are always long latency, false sharing of atomic variables, or branches that are often mis-predicted and causing slow-downs.
 Because SPE is precise, this information can be attributed back to individual code lines that need to be optimized.
-SPE is enabled Graviton 2 and 3 metal instances.  The below table shows for which Linux distributions and kernel versions SPE is known to be
+SPE is enabled Graviton 2,3, and 4 metal instances.  The below table shows for which Linux distributions and kernel versions SPE is known to be
 enabled.
 
 | Distro       | Kernel  |


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Update `perfrunbook/debug_hw_perf.md` to list that SPE is supported on Graviton 4 metal instances.

Support for SPE on Graviton 4 metal instances was verified on AL2023

```
[ec2-user@ip-172-31-75-66 ~]$ ec2-metadata --instance-type
instance-type: m8g.metal-24xl
[ec2-user@ip-172-31-75-66 ~]$ uname -r
6.1.166-197.305.amzn2023.aarch64
[ec2-user@ip-172-31-75-66 ~]$ cat /boot/config-$(uname -r) | grep CONFIG_ARM_SPE_PMU
CONFIG_ARM_SPE_PMU=y
[ec2-user@ip-172-31-75-66 ~]$ ls /sys/devices/arm_spe_0
caps  cpumask  format  perf_event_mux_interval_ms  power  subsystem  type  uevent
```
And on Ubuntu 22.04 to confirm that module loading instructions were still accurate.
```
ubuntu@ip-172-31-75-157:~$ ec2-metadata --instance-type
instance-type: m8g.metal-24xl
ubuntu@ip-172-31-75-157:~$ uname -r
6.8.0-1046-aws
ubuntu@ip-172-31-75-157:~$ cat /boot/config-$(uname -r) | grep CONFIG_ARM_SPE_PMU
CONFIG_ARM_SPE_PMU=m
ubuntu@ip-172-31-75-157:~$ lsmod | grep arm_spe_pmu
arm_spe_pmu            24576  0
ubuntu@ip-172-31-75-157:~$ ls /sys/devices/arm_spe_0
caps  cpumask  format  perf_event_mux_interval_ms  power  subsystem  type  uevent
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
