### PR TITLE
docs-perfrunbook: refresh outdated external links

### DIFF
--- a/perfrunbook/debug_system_perf.md
+++ b/perfrunbook/debug_system_perf.md
@@ -121,7 +121,7 @@ Checking how your chosen runtime is behaving should be done before moving on to 
 When running Java applications, monitor for differences in behavior using JFR (Java Flight Recorder) to record JVM behavior and view with JMC (Java Mission Control). These can expose different execution behaviors as reasons for performance differences.
 
 1. Enable a JFR recording for your application by adding `-XX:+FlightRecorder -XX:StartFlightRecording=delay=<X>s,duration=<X>s,name=<name>,filename=path/to/recording.jfr` to the JVM command line.
-    1. Get [Java Mission Control](https://www.oracle.com/java/technologies/javase/products-jmc8-downloads.html)
+    1. Get [JDK Mission Control](https://www.oracle.com/java/technologies/jdk-mission-control.html)
     2. Download the resulting JFR file to local machine
     3. Open up the JFR file with Mission Control
 2. Check for Garbage Collection (GC) behavior

--- a/perfrunbook/references.md
+++ b/perfrunbook/references.md
@@ -9,19 +9,20 @@ Experimental design:
 
 Performance measurement tools:
 
-* [Top-down performance analysis](https://drive.google.com/file/d/0B_SDNxjh2Wbcc0lWemFNSGMzLTA/view)
+* [Top-down performance analysis (Yasin, ISPASS 2014)](https://ieeexplore.ieee.org/document/6844459)
+* [The PMCs of EC2: Measuring IPC (Brendan Gregg)](https://www.brendangregg.com/blog/2017-05-04/the-pmcs-of-ec2.html)
 * [Brendan Gregg's homepage](http://www.brendangregg.com/overview.html)
 * [Flamegraph homepage](https://github.com/brendangregg/FlameGraph)
 * https://github.com/andikleen/pmu-tools
-* [Netstat man-page](https://linux.die.net/man/8/netstat)
-* [Sar man-page](https://linux.die.net/man/1/sar)
-* [perf-stat man-page](https://linux.die.net/man/1/perf-stat)
-* [perf-record man-page](https://linux.die.net/man/1/perf-record)
-* [perf-annotate man-page](https://linux.die.net/man/1/perf-annotate)
+* [Netstat man-page](https://man7.org/linux/man-pages/man8/netstat.8.html)
+* [Sar man-page](https://man7.org/linux/man-pages/man1/sar.1.html)
+* [perf-stat man-page](https://man7.org/linux/man-pages/man1/perf-stat.1.html)
+* [perf-record man-page](https://man7.org/linux/man-pages/man1/perf-record.1.html)
+* [perf-annotate man-page](https://man7.org/linux/man-pages/man1/perf-annotate.1.html)
 
 Optimization and tuning:
 
-* [GCC10 manual](https://gcc.gnu.org/onlinedocs/gcc-10.2.0/gcc.pdf)
+* [GCC online documentation](https://gcc.gnu.org/onlinedocs/)
 * [Optimizing network intensive workloads on Graviton1](https://aws.amazon.com/blogs/compute/optimizing-network-intensive-workloads-on-amazon-ec2-a1-instances/)
 * [Optimizing NGINX on Graviton1](https://aws.amazon.com/blogs/compute/optimizing-nginx-load-balancing-on-amazon-ec2-a1-instances/)
 * [sysctl tunings](https://github.com/amazonlinux/autotune/blob/master/src/ec2sys_autotune/ec2_instance_network_cfg_gen.py#L63-L64)
@@ -31,6 +32,6 @@ Hardware reference manuals:
 
 * [Arm64 Architecture Reference Manual](https://developer.arm.com/documentation/102105/latest)
 * [Neoverse N1 Technical Reference Manual](https://developer.arm.com/documentation/100616/0400/debug-descriptions/performance-monitor-unit/pmu-events)
-* Reference for Intel CPU PMU counters (c5/m5/r5): [Intel 64 and IA-32 Architecture Software Developer’s Manual, Volume 3B Chapter 19](https://software.intel.com/content/dam/develop/external/us/en/documents-tps/253669-sdm-vol-3b.pdf)
+* Reference for Intel CPU PMU counters (c5/m5/r5): [Intel 64 and IA-32 Architectures Software Developer's Manual](https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html) (see Volume 3B, Performance Monitoring chapters)
 * Reference for AMD CPU PMU counters (c5a): [Processor Programming Reference (PPR) for AMD Family 17h Model 71h, Revision B0 Processors Section 2.1.15](https://www.amd.com/system/files/TechDocs/56176_ppr_Family_17h_Model_71h_B0_pub_Rev_3.06.zip)
 


### PR DESCRIPTION
*Description of changes:*

Several external references in the runbook pointed to legacy URLs that have either moved or are no longer maintained:

- 'Java Mission Control' linked to the JMC 8 download page; Oracle has rolled the page into a single product landing page that surfaces the current LTS (JMC 9.x) build.
- 'Top-down performance analysis' linked to a personal Google Drive copy of the slide deck, which is fragile (the share could be revoked or moved at any time).  Replaced with two stable references: the upstream IEEE ISPASS 2014 paper by Ahmad Yasin that introduced the method, and Brendan Gregg's 'PMCs of EC2' overview.
- 'GCC10 manual' linked to a frozen GCC 10.2.0 PDF; replaced with gcc.gnu.org/onlinedocs which always serves the current release.
- 'Intel 64 and IA-32 Software Developer's Manual' linked to a PDF hosted under software.intel.com (which Intel has retired and 301-redirects to a generic page).  Replaced with the supported intel.com/.../intel-sdm landing page.
- The five 'man-page' entries pointed at linux.die.net, which is unmaintained and lags the upstream release by years.  Replaced with the equivalent pages on man7.org which is the current reference site for Linux man-pages.


