### PR TITLE
fix-perfrunbook: refresh OS-support list and kernel-upgrade guidance

### DIFF
--- a/perfrunbook/README.md
+++ b/perfrunbook/README.md
@@ -10,14 +10,14 @@ If after following these guides there is still an issue you cannot resolve with 
 
 ## Pre-requisites
 
-To assist with some of the tasks listed in this runbook, we have created some helper-scripts for some of the tasks the checklists describe.  The helper-scripts assume the test instances are running an up-to-date AL2, AL2023 or Ubuntu 20.04LTS/22.04LTS distribution and the user can run the scripts using `sudo`. Follow the steps below to obtain and install the utilities on your test systems:
+To assist with some of the tasks listed in this runbook, we have created some helper-scripts for some of the tasks the checklists describe.  The helper-scripts assume the test instances are running an up-to-date Amazon Linux 2023, Ubuntu 22.04 LTS, Ubuntu 24.04 LTS, RHEL 9.5, or SLES 15 SP6 distribution and the user can run the scripts using `sudo`.  Amazon Linux 2 and Ubuntu 20.04 are still recognized by `install_perfrunbook_dependencies.sh` for backward compatibility, but both are past their standard end-of-support and are not recommended for new performance work.  Follow the steps below to obtain and install the utilities on your test systems:
 
 ```bash
 # Clone the repository onto your systems-under-test and any load-generation instances
 git clone https://github.com/aws/aws-graviton-getting-started.git
 cd aws-graviton-getting-started/perfrunbook/utilities
 
-# On AL2 or Ubuntu distribution
+# On AL2023, Ubuntu, RHEL or SLES
 sudo ./install_perfrunbook_dependencies.sh
 
 # All scripts expect to run from the utilities directory

--- a/perfrunbook/configuring_your_sut.md
+++ b/perfrunbook/configuring_your_sut.md
@@ -31,22 +31,21 @@ If you have more than one SUT, first verify there are no major differences in se
   ```
 3. Check all instances are running the same major and minor kernel versions.  It is recommended to upgrade to the newest kernel available to bring in the latest security and bug fixes.
   ```bash
-  # Example output on x86 SUT
+  # Example output on Graviton SUT (Amazon Linux 2023)
   %> uname -r
-  4.14.219-161.340.amzn2.x86_64
+  6.1.84-99.169.amzn2023.aarch64
     
-  # Example output on Graviton SUT
+  # Example output on x86 SUT (Amazon Linux 2023)
   %> uname -r
-  5.10.50-45.132.amzn2.aarch64
+  6.1.84-99.169.amzn2023.x86_64
     
-  # To upgrade on AL2 for example to Linux 5.10:
-  %> sudo amazon-linux-extras enable kernel-5.10
-  %> sudo yum install kernel
+  # Update on Amazon Linux 2023 to the latest kernel:
+  %> sudo dnf update kernel
     
-  # To update on Ubuntu
-  %> sudo apt-cache search "linux-image"
-  # Find the newest kernel available
-  %> sudo apt-get install linux-image-<version>-generic
+  # Update on Ubuntu (HWE kernel is recommended for latest hardware support
+  # including SPE on Graviton metal instances)
+  %> sudo apt-get install linux-generic-hwe-22.04   # Ubuntu 22.04
+  %> sudo apt-get install linux-generic-hwe-24.04   # Ubuntu 24.04
     
   # Restart your instance
   %> sudo reboot now


### PR DESCRIPTION
*Description of changes:*

- README: align distro list with what `install_perfrunbook_dependencies.sh` actually supports (AL2023, Ubuntu 22.04/24.04, RHEL 9.5, SLES 15 SP6) - reference `utilities/install_perfrunbook_dependencies.sh` lines 135–154
- README: note AL2 and Ubuntu 20.04 are past end-of-support
- configuring_your_sut.md: use AL2023 kernel 6.1+ for uname examples
- configuring_your_sut.md: replace `amazon-linux-extras enable kernel-5.10` with `dnf update kernel` (the AL2023 path)
- configuring_your_sut.md: replace manual apt-cache search with HWE meta-package install (linux-generic-hwe-{22,24}.04), which is the recommended path for getting SPE support on Graviton metal instances

