### PR TITLE
fix-perfrunbook: correct sysctl syntax and TIME_WAIT guidance in configuring_your_loadgen.md

### DIFF
--- a/perfrunbook/configuring_your_loadgen.md
+++ b/perfrunbook/configuring_your_loadgen.md
@@ -37,13 +37,12 @@ The load generator setup is important to understand and verify: it generates the
    # port exhaustion is happening and can lead to decrease in driven load.  Use the below tips to
    # fix the issue.
    
-   # Increase ephemeral port range on load generator/SUT
-   %> sudo sysctl -w net.ipv4.ip_local_port_range 1024 65535
-   # If you application uses IPv6
-   %> sudo sysctl -w net.ipv6.ip_local_port_range 1024 65535
+   # Widen the ephemeral port range (applies to both IPv4 and IPv6)
+   %> sudo sysctl -w net.ipv4.ip_local_port_range="1024 65535"
    
-   # Allow kernel to re-use connections in load generator/SUT
-   %> sysctl -w net.ipv4.tcp_tw_reuse=1
+   # Reuse TIME_WAIT sockets for outgoing connections (relies on TCP
+   # timestamps; avoid behind SNAT/MASQUERADE where timestamps are rewritten).
+   %> sudo sysctl -w net.ipv4.tcp_tw_reuse=1
    ```
 8. Check connection rates on SUT.  Do you see constant rate of new connections or bursty behavior? Does it match the expectations for the workload? 
    ```bash


### PR DESCRIPTION
1. `sudo sysctl -w net.ipv4.ip_local_port_range 1024 65535` is not legal sysctl(8) syntax — the `procps` tool requires `key=value`, and multi-word values must be quoted. Anyone copy-pasting hits sysctl: malformed setting `net.ipv4.ip_local_port_range` The unquoted example would be correct if writing values to `/etc/sysctl.conf`

2. `net.ipv6.ip_local_port_range` does not exist. The kernel's `documentation/networking/ip-sysctl.rst` documents only `net.ipv4.ip_local_port_range`, and that single setting is shared by IPv4 and IPv6 ephemeral port selection

3. `tcp_tw_reuse=1` deserves a NAT caveat. `tcp_tw_reuse=1` reuses `TIME_WAIT` sockets in the outgoing direction only and relies on TCP timestamps. It is generally safe but can cause connection resets when the load generator is behind NAT or its peer rewrites timestamps; readers should not enable it blindly.

*Description of changes:*

- Fix `sysctl -w` to use required `key=value` syntax with quoted value
- Remove non-existent `net.ipv6.ip_local_port_range` line
- Add `sudo` to `tcp_tw_reuse` command
- Add concise SNAT/MASQUERADE caveat for `tcp_tw_reuse`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
