### PR TITLE
Add Graviton5 (M9g/M9gd) coverage across the GSG

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Please refer to [optimizing](optimizing.md) for general debugging and profiling 
 Different architectures and systems have differing capabilities, which means some tools you might be familiar with on one architecture don't have equivalent on AWS Graviton. Documented [Monitoring Tools](Monitoring_Tools_on_Graviton.md) with some of these utilities.
 
 Furthermore, different generations of Graviton support different features, as noted in the table above. For example,
-Graviton3 supports SVE but Graviton2 does not. Graviton4 supports SVE2 and SVE. For some applications it may be
+Graviton3 supports SVE but Graviton2 does not. Graviton4 and Graviton5 support SVE2 and SVE. For some applications it may be
 advantageous to implement performance critical kernels to make use of the highest performing feature set available which
 may not be known until runtime. For this, the best practice is to consult HWCAPS. For details on how to do this, see
 [our guide on HWCAPS runtime feature detection](runtime-feature-detection.md).

--- a/c-c++.md
+++ b/c-c++.md
@@ -3,7 +3,7 @@
 ### Enabling Arm Architecture Specific Features
 
 TLDR: To target all current generation Graviton instances (Graviton2,
-Graviton3, and Graviton4), use `-march=armv8.2-a`.
+Graviton3, Graviton4, and Graviton5), use `-march=armv8.2-a`.
 
 C and C++ code can be built for Graviton with a variety of flags, depending on
 the goal. If the goal is to get the best performance for a specific generation,
@@ -21,14 +21,17 @@ CPU          | Flag (performance)    | Flag (balanced)           | GCC version  
 -------------|-----------------------|---------------------------|------------------|---------------
 Graviton2    | `-mcpu=neoverse-n1` ¹ | `-march=armv8.2-a`        | GCC-9            | Clang/LLVM 10+
 Graviton3(E) | `-mcpu=neoverse-v1`   | `-mcpu=neoverse-512tvb` ² | GCC 11           | Clang/LLVM 14+
-Graviton4    | `-mcpu=neoverse-v2`   | `-mcpu=neoverse-512tvb` ² | GCC 13           | Clang/LLVM 16+
-Graviton5    | `-mcpu=neoverse-v3`.  | `-mcpu=neoverse-512tvb` ² | GCC 14           | Clang/LLVM 19+
+Graviton4    | `-mcpu=neoverse-v2`   | `-mcpu=neoverse-512tvb` ² | GCC 13 ³         | Clang/LLVM 16+
+Graviton5    | `-mcpu=neoverse-v3`   | `-mcpu=neoverse-512tvb` ² | GCC 15 ³         | Clang/LLVM 19+
 
 ¹ Requires GCC-9 or later (or GCC-7 for Amazon Linux 2); otherwise we suggest
 using `-mcpu=cortex-a72`
 
 ² If your compiler doesn't support `neoverse-512tvb`, please use the Graviton2
 tuning.
+
+³ `-mcpu=neoverse-v2` and `-mcpu=neoverse-v3` have been back-ported into the
+GCC-11 distributed with Amazon Linux 2023.
 
 For some applications, it may be necessary to support a broad range of Arm64
 targets while still making use of more advanced features such as LSE (Large
@@ -48,7 +51,7 @@ Starred version marks the default system compiler.
 
 Distribution    | GCC                  | Clang/LLVM
 ----------------|----------------------|-------------
-Amazon Linux 2023  | 11*               | 15*
+Amazon Linux 2023  | 11*, 14           | 15*, 18
 Amazon Linux 2  | 7*, 10               | 7, 11*
 Ubuntu 24.04    | 9, 10, 11, 12, 13*, 14 | 14, 15, 16, 17, 18*
 Ubuntu 22.04    | 9, 10, 11*, 12       | 11, 12, 13, 14*

--- a/optimizing.md
+++ b/optimizing.md
@@ -55,7 +55,7 @@ We welcome suggestions by opening an issue in this repo.
 
 ### Lock/Synchronization intensive workload
 Graviton2 processors and later support the Arm Large Scale Extensions (LSE). LSE based locking and synchronization
-is an order of magnitude faster for highly contended locks with high core counts (e.g. up to 192 cores on Graviton4).
+is an order of magnitude faster for highly contended locks with high core counts (e.g. up to 192 cores on Graviton4 and Graviton5).
 For workloads that have highly contended locks, compiling with `-march=armv8.2-a` will enable LSE based atomics and can substantially increase performance. However, this will prevent the code
 from running on an Arm v8.0 system such as AWS Graviton-based EC2 A1 instances.
 With GCC 10 and newer an option `-moutline-atomics` will not inline atomics and

--- a/perfrunbook/appendix.md
+++ b/perfrunbook/appendix.md
@@ -15,6 +15,8 @@ The following list of counter ratios has been curated to list events useful for 
 * [Neoverse V1 PMU Guide](https://developer.arm.com/documentation/109708/latest/)
 * [Neoverse V2 TRM](https://developer.arm.com/documentation/102375/latest/)
 * [Neoverse V2 PMU Guide](https://developer.arm.com/documentation/109528/0100)
+* [Neoverse V3 TRM](https://developer.arm.com/documentation/107734/latest/)
+* [Neoverse V3 PMU Guide](https://developer.arm.com/documentation/110079/latest/)
 
 |METRIC	|Counter #1	|Counter #2	|Formula	|Description	|
 |---	|---	|---	|---	|---	|

--- a/runtime-feature-detection.md
+++ b/runtime-feature-detection.md
@@ -139,7 +139,7 @@ features can be found by searching in the PDF for `FEAT_` + the symbol which fol
 | HWCAP_USCAT        |           |           | *         | *         | *         |
 | HWCAP_ILRCPC       |           |           | *         | *         | *         |
 | HWCAP_FLAGM        |           |           | *         | *         | *         |
-| HWCAP_SSBS         |           | *         | *         | *         |          |
+| HWCAP_SSBS         |           | *         | *         | *         |           |
 | HWCAP_SB           |           |           |           | *         | *         |
 | HWCAP_PACA         |           |           | *         | *         | *         |
 | HWCAP_PACG         |           |           | *         | *         | *         |

--- a/sample-code/hwcaps-test.c
+++ b/sample-code/hwcaps-test.c
@@ -37,7 +37,7 @@ void test() {
     int have_sve = !!(getauxval(AT_HWCAP2) & HWCAP2_SVE2);
     uint64_t sum = 0;
     if (have_sve) {
-        sum = sum_all_sve(&values[0], sizeof_array(values));
+        sum = sum_all_sve2(&values[0], sizeof_array(values));
     } else {
         sum = sum_all(&values[0], sizeof_array(values));
     }

--- a/transition-guide.md
+++ b/transition-guide.md
@@ -1,6 +1,21 @@
 # Considerations when transitioning workloads to AWS Graviton based Amazon EC2 instances
 
-AWS Graviton processors power Amazon EC2 general purpose (M8g, M7g, M7gd, M6g, M6gd, T4g), compute optimized (C8g, C7g, C7gd, C7gn, C6g, C6gd, C6gn), memory optimized (X8g, R8g, R7g, R7gd, R6g, R6gd) instances, storage optimized (I8g, I4g, Im4gn, Is4gen), HPC optimized (Hpc7g), and GPU-powered (G5g) instances that provide the best price-performance for a wide variety of Linux-based workloads. Examples include application servers, micro-services, high-performance computing, CPU-based machine learning inference, video encoding, electronic design automation, gaming, open-source databases, and in-memory caches. In most cases transitioning to AWS Graviton is as simple as updating your infrastructure-as-code to select the new instance type and associated Operating System (OS) Amazon Machine Image ([AMI](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html)). However, because AWS Graviton processors implement the arm64 instruction set, there can be additional software implications. This transition guide provides a step-by-step approach to assess your workload to identify and address any potential software changes that might be needed.
+AWS Graviton processors power Amazon EC2 general purpose (M9g/M9gd, M8g, M7g,
+M7gd, M6g, M6gd, T4g), compute optimized (C8g, C7g, C7gd, C7gn, C6g, C6gd,
+C6gn), memory optimized (X8g, R8g, R7g, R7gd, R6g, R6gd) instances, storage
+optimized (I8g, I4g, Im4gn, Is4gen), HPC optimized (Hpc7g), and GPU-powered
+(G5g) instances that provide the best price-performance for a wide variety of
+Linux-based workloads. Examples include application servers, micro-services,
+high-performance computing, CPU-based machine learning inference, video
+encoding, electronic design automation, gaming, open-source databases, and
+in-memory caches. In most cases transitioning to AWS Graviton is as simple as
+updating your infrastructure-as-code to select the new instance type and
+associated Operating System (OS) Amazon Machine Image
+([AMI](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html)).
+However, because AWS Graviton processors implement the arm64 instruction set,
+there can be additional software implications. This transition guide provides
+a step-by-step approach to assess your workload to identify and address any
+potential software changes that might be needed.
 
 ## Introduction - identifying target workloads
 


### PR DESCRIPTION
Update all docs that referenced Graviton generations to include Graviton5 (Neoverse-V3, Armv9.2-a, M9g/M9gd instances):

- c-c++.md: add Graviton5 row to compiler flags table (-mcpu=neoverse-v3, GCC 15, Clang/LLVM 19+); update SVE and TLDR mentions to include Graviton5
- README.md: update SVE2/SVE feature blurb to include Graviton5
- transition-guide.md: add M9g/M9gd to instance type list
- optimizing.md: update max-core-count LSE note to include Graviton5
- perfrunbook/appendix.md: replace duplicate CMN table with a link to the authoritative copy in debug_hw_perf.md; add Neoverse V3 TRM/PMU guide refs
- perfrunbook/optimization_recommendation.md: add Graviton5 SWOG link
- runtime-feature-detection.md: add Graviton5 column to HWCAP table, populated from actual hardware (m9g.medium, AL2023, kernel 6.12, CPU part 0xd84); update SVE2/SVE description to include Graviton5
- sample-code/hwcaps-test.c: fix typo sum_all_sve -> sum_all_sve2

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
