### PR TITLE
Several updates to the FFmpeg builder

### DIFF
--- a/video-encoding/ffmpeg-build/Dockerfile
+++ b/video-encoding/ffmpeg-build/Dockerfile
@@ -39,6 +39,7 @@ RUN HIGH_BIT_DEPTH=1 PREFIX=/usr/local scripts/build-x265.sh
 
 # == aom ==
 FROM base AS aom
+COPY patches /build/patches
 COPY sources/aom sources/aom
 RUN PREFIX=/usr/local scripts/build-aom.sh
 

--- a/video-encoding/ffmpeg-build/README.md
+++ b/video-encoding/ffmpeg-build/README.md
@@ -12,7 +12,7 @@ This tool makes it easy to build optimized, up-to-date FFmpeg packages with a si
 
 - Single-file Python script for building FFmpeg with common codecs
 - Produces native packages (RPM for Amazon Linux, DEB for Ubuntu)
-- Optimized for Graviton2/3/4 and x86_64 (AVX2/AVX512)
+- Optimized for Graviton2/3/4/5 and x86_64 (AVX2/AVX512)
 - Includes x264, x265 (8-bit + 10-bit), AOM, SVT-AV1, and Opus
 - Docker-based builds for reproducibility
 - Test mode to verify packages work correctly
@@ -89,10 +89,12 @@ The config file (`ffmpeg_build_config.json`) supports:
 ### Options
 
 - `target_distro`: al2023, ubuntu-jammy, ubuntu-noble, ubuntu-resolute
-- `target_platform`: graviton2, graviton3, graviton4, avx2, avx512
+- `target_platform`: graviton2, graviton3, graviton4, graviton5, avx2, avx512
 - `compiler`: gcc, clang, gcc-latest, clang-latest, or specific versions (see below)
 - `build_type`: "release" (latest tags) or "tip" (main branches)
 - `commit_overrides`: Pin specific projects to exact commits/tags
+
+**Graviton5 compiler requirements:** Full Graviton5 optimization (`-march=armv9.2-a`, `-mtune=neoverse-v3`) requires GCC ≥ 15 or Clang ≥ 19. The build will succeed on older compilers by automatically falling back to Graviton4-equivalent flags (`-march=armv9-a`, `-mtune=neoverse-v2`) with a warning. For best performance on Graviton5 instances, use `clang-latest` on AL2023, Ubuntu Noble, or Ubuntu Resolute (which provide Clang 19+).
 
 Available compilers by distro:
 - AL2023: gcc (11), gcc11, gcc14, clang (15), clang15, clang18, clang19

--- a/video-encoding/ffmpeg-build/build_ffmpeg.py
+++ b/video-encoding/ffmpeg-build/build_ffmpeg.py
@@ -26,7 +26,7 @@ OUTPUT_DIR = SCRIPT_DIR / "output"
 DEFAULT_REPOS = {
     "ffmpeg": "https://git.ffmpeg.org/ffmpeg.git",
     "x264": "https://code.videolan.org/videolan/x264.git",
-    "x265": "https://bitbucket.org/multicoreware/x265_git",
+    "x265": "https://github.com/Multicorewareinc/x265.git",
     "aom": "https://aomedia.googlesource.com/aom",
     "SVT-AV1": "https://gitlab.com/AOMediaCodec/SVT-AV1.git",
     "opus": "https://github.com/xiph/opus.git",
@@ -86,7 +86,7 @@ DEFAULT_VERSIONS = {
     "opus": "v1.5.2",
 }
 
-VALID_PLATFORMS = {"graviton2", "graviton3", "graviton4", "avx2", "avx512"}
+VALID_PLATFORMS = {"graviton2", "graviton3", "graviton4", "graviton5", "avx2", "avx512"}
 
 
 def _default_platform():

--- a/video-encoding/ffmpeg-build/patches/aom-nasm3-compat.patch
+++ b/video-encoding/ffmpeg-build/patches/aom-nasm3-compat.patch
@@ -1,11 +1,23 @@
 --- a/build/cmake/aom_optimization.cmake
 +++ b/build/cmake/aom_optimization.cmake
-@@ -212,7 +212,7 @@ macro(add_nasm_library)
-     # nasm 2.14+ uses -O2 by default, but the help still shows -Ox is the
-     # default. Check to see if -O2 is supported, and if so, use it.
-     unset(NASM_OFLAG)
--    execute_process(COMMAND ${CMAKE_ASM_NASM_COMPILER} -hf
-+    execute_process(COMMAND ${CMAKE_ASM_NASM_COMPILER} -h
-                     OUTPUT_VARIABLE nasm_helptext)
+@@ -212,10 +212,19 @@
+ # Currently checks only for presence of required object formats and support for
+ # the -Ox argument (multipass optimization).
+ function(test_nasm)
++  # nasm 3.x split its help output: the object formats (elf64, macho32, ...)
++  # are listed by `-hf`, while the optimization flags moved to the base `-h`
++  # output. The `-Ox` flag still exists in 3.x but its help text now reads
++  # "select optimization" rather than the bare "-Ox" token that aom's original
++  # regex matched. Capture both `-hf` and `-h` and match either pattern so the
++  # checks below work with nasm 2.x and 3.x.
+   execute_process(COMMAND ${CMAKE_ASM_NASM_COMPILER} -hf
+                   OUTPUT_VARIABLE nasm_helptext)
++  execute_process(COMMAND ${CMAKE_ASM_NASM_COMPILER} -h
++                  OUTPUT_VARIABLE nasm_opt_helptext)
++  string(APPEND nasm_helptext "${nasm_opt_helptext}")
  
-     if("${nasm_helptext}" MATCHES "-O2")
+-  if(NOT "${nasm_helptext}" MATCHES "-Ox")
++  if(NOT "${nasm_helptext}" MATCHES "-Ox|select optimization")
+     message(
+       FATAL_ERROR "Unsupported nasm: multipass optimization not supported.")
+   endif()

--- a/video-encoding/ffmpeg-build/scripts/build-aom.sh
+++ b/video-encoding/ffmpeg-build/scripts/build-aom.sh
@@ -6,8 +6,30 @@ PREFIX=${PREFIX:-/usr/local}
 AOM_SRC="${SCRIPT_DIR}"/../sources/aom
 
 # Apply nasm 3.x compatibility patch
-# nasm 3.x moved -O optimization docs from "nasm -hf" to "nasm -h"
-patch -d "${AOM_SRC}" -p1 -N < "${SCRIPT_DIR}"/../patches/aom-nasm3-compat.patch || true
+# nasm 3.x changed how -O optimization is documented; the patch adjusts aom's
+# CMake detection so it works with both nasm 2.x and 3.x.
+# Use --dry-run with -R to check if already applied; only apply if needed.
+# If the patch fails (e.g. aom version bump), check whether aom already handles
+# nasm 3.x natively before failing — future aom releases may incorporate the fix.
+if [ "${SKIP_AOM_NASM_PATCH:-0}" = "1" ]; then
+    echo "Skipping nasm 3.x patch (SKIP_AOM_NASM_PATCH=1)"
+else
+    PATCH_FILE="${SCRIPT_DIR}"/../patches/aom-nasm3-compat.patch
+    AOM_NASM_CMAKE="${AOM_SRC}/build/cmake/aom_optimization.cmake"
+    if patch -d "${AOM_SRC}" -p1 -R --dry-run < "$PATCH_FILE" >/dev/null 2>&1; then
+        echo "nasm 3.x patch already applied, skipping"
+    elif patch -d "${AOM_SRC}" -p1 -N --dry-run < "$PATCH_FILE" >/dev/null 2>&1; then
+        patch -d "${AOM_SRC}" -p1 -N < "$PATCH_FILE"
+    elif grep -q "select optimization" "$AOM_NASM_CMAKE" 2>/dev/null; then
+        echo "aom already supports nasm 3.x natively, patch not needed"
+    else
+        echo "Error: nasm 3.x compatibility patch failed to apply and aom does not"
+        echo "       appear to have native nasm 3.x support."
+        echo "       Regenerate the patch for the current aom version, or set"
+        echo "       SKIP_AOM_NASM_PATCH=1 to bypass if you are using nasm 2.x."
+        exit 1
+    fi
+fi
 
 cd "${AOM_SRC}"
 rm -rf aom_build

--- a/video-encoding/ffmpeg-build/scripts/build-x265.sh
+++ b/video-encoding/ffmpeg-build/scripts/build-x265.sh
@@ -5,17 +5,69 @@ set -euxo pipefail
 PREFIX=${PREFIX:-/usr/local}
 HIGH_BIT_DEPTH=${HIGH_BIT_DEPTH:-0}
 
-BUILD_CONFIG_FLAGS=""
+# Enable assembly optimizations. This is the bulk of x265's performance on both
+# ARM (Neon/DotProd/I8MM/SVE/SVE2) and x86 (nasm), so it must stay on whenever
+# the toolchain can build it.
+#
+# x265's CMake already degrades gracefully across most aarch64 extensions, with
+# one gap: its SVE2 assembly (.S) is *always* compiled with
+# -march=armv9-a+i8mm+sve2 regardless of target platform. Toolchains that cannot
+# assemble that fail the whole build. Empirically (x265 4.1, validated on a
+# Graviton4 host) this affects:
+#   - gcc   < 12  (cc1 has no armv9-a)
+#   - clang < 15  (integrated assembler rejects the SVE2 .S files)
+# Every other aarch64 assembly path (~20 objects) still builds on those
+# compilers. So instead of disabling ALL assembly (the previous behavior, which
+# also needlessly dropped the x86 nasm paths for the default gcc/clang names),
+# keep assembly on and disable ONLY SVE2 when the active compiler cannot build
+# it. Capability is probed directly so this stays correct for future toolchains
+# without per-version maintenance.
+BUILD_CONFIG_FLAGS="-DENABLE_ASSEMBLY=ON"
 
-# Disable assembly for older compilers that can't handle ARM intrinsics
-case "${CC:-gcc}" in
-    gcc|gcc-[0-9]|gcc-1[0-3])
-        BUILD_CONFIG_FLAGS="-DENABLE_ASSEMBLY=OFF"
-        ;;
-    clang|clang-[0-9]|clang-1[0-7])
-        BUILD_CONFIG_FLAGS="-DENABLE_ASSEMBLY=OFF"
-        ;;
-esac
+CC_BIN="${CC:-gcc}"
+# x265's hand-written SVE2 assembly requires a compiler that can assemble
+# -march=armv9-a+i8mm+sve2. Probe whether it can, then:
+#   - If target CFLAGS request +sve2 but compiler can't: error (silent perf loss)
+#   - If target doesn't need SVE2 but compiler can't: just disable SVE2 assembly
+#
+# NOTE: The probe uses -march=armv9-a+i8mm+sve2 because that's the exact flag
+# x265 4.1 passes to compile its SVE2 .S files (source/common/aarch64/CMakeLists.txt).
+# The .arch directive in the probe (.arch armv8-a+sve2) tests assembler acceptance
+# of SVE2 mnemonics. Both gates must pass for x265's SVE2 objects to build.
+# Re-verify this flag if x265 is bumped beyond 4.1.
+if echo "${CFLAGS:-}" | grep -q "+sve2"; then
+    SVE2_PROBE="$(mktemp --suffix=.S)"
+    printf '.arch armv8-a+sve2\nptrue p0.b, vl8\nsqrdmlah z0.s, z1.s, z2.s\nret\n' > "$SVE2_PROBE"
+    if ! "${CC_BIN}" -march=armv9-a+i8mm+sve2 -c "$SVE2_PROBE" -o /dev/null >/dev/null 2>&1; then
+        rm -f "$SVE2_PROBE"
+        echo "Error: ${CC_BIN} cannot assemble SVE2, but target platform requires it."
+        echo "       Use GCC >= 12 or Clang >= 15."
+        exit 1
+    fi
+    rm -f "$SVE2_PROBE"
+elif echo "${CFLAGS:-}" | grep -q "armv8"; then
+    # ARM target without SVE2 (graviton2/3) — disable SVE2 assembly, keep the rest
+    SVE2_PROBE="$(mktemp --suffix=.S)"
+    printf '.arch armv8-a+sve2\nptrue p0.b, vl8\nsqrdmlah z0.s, z1.s, z2.s\nret\n' > "$SVE2_PROBE"
+    if ! "${CC_BIN}" -march=armv9-a+i8mm+sve2 -c "$SVE2_PROBE" -o /dev/null >/dev/null 2>&1; then
+        BUILD_CONFIG_FLAGS="${BUILD_CONFIG_FLAGS} -DENABLE_SVE2=OFF"
+    fi
+    rm -f "$SVE2_PROBE"
+fi
+
+# CMake 4.x (shipped by e.g. Ubuntu resolute) removed support for the legacy
+# cmake_minimum_required (<3.5) and for setting policies CMP0025/CMP0054 to OLD
+# behavior, all of which x265 4.1's CMakeLists still uses. Make the project
+# configure under modern CMake while staying compatible with older CMake:
+#   - rewrite the two policies to NEW (accepted by every CMake >= 3.0; on Linux
+#     the OLD/NEW distinction for these two is immaterial). Idempotent.
+#   - allow the old minimum-version declaration via CMAKE_POLICY_VERSION_MINIMUM
+#     (silently ignored by CMake versions predating that variable).
+X265_CMAKELISTS="${SCRIPT_DIR}/../sources/x265/source/CMakeLists.txt"
+sed -i -e 's/cmake_policy(SET CMP0025 OLD)/cmake_policy(SET CMP0025 NEW)/' \
+       -e 's/cmake_policy(SET CMP0054 OLD)/cmake_policy(SET CMP0054 NEW)/' \
+       "${X265_CMAKELISTS}"
+BUILD_CONFIG_FLAGS="${BUILD_CONFIG_FLAGS} -DCMAKE_POLICY_VERSION_MINIMUM=3.5"
 
 cd "${SCRIPT_DIR}"/../sources/x265/build/linux
 rm -rf *

--- a/video-encoding/ffmpeg-build/scripts/install-dependencies.sh
+++ b/video-encoding/ffmpeg-build/scripts/install-dependencies.sh
@@ -28,6 +28,7 @@ function amazon_linux_2023_dependencies() {
         make \
         numactl-devel \
         ninja-build \
+        patch \
         pkgconfig \
         python3-pip \
         nasm \
@@ -113,6 +114,7 @@ function ubuntu_dependencies() {
         libfreetype6-dev \
         libtool \
         ninja-build \
+        patch \
         pkg-config \
         texinfo \
         wget \

--- a/video-encoding/ffmpeg-build/scripts/setup-compiler.sh
+++ b/video-encoding/ffmpeg-build/scripts/setup-compiler.sh
@@ -33,7 +33,35 @@ if ! command -v "$CC" &>/dev/null; then
     exit 1
 fi
 
+# ---------------------------------------------------------------------------
+# Compiler capability probe helper
+# Usage: compiler_accepts_flags <flag> [<flag> ...]
+# Returns 0 if the compiler can compile an empty C file with the given flags.
+# ---------------------------------------------------------------------------
+compiler_accepts_flags() {
+    local probe
+    probe="$(mktemp --suffix=.c)"
+    printf 'int main(void){return 0;}\n' > "$probe"
+    local rc=0
+    "$CC" "$@" -c "$probe" -o /dev/null >/dev/null 2>&1 || rc=$?
+    rm -f "$probe"
+    return $rc
+}
+
 # Set platform-specific flags
+#
+# Graviton5 targets Neoverse V3 / Armv9.2-a. Compiler support for the ideal
+# flags varies, so rather than hard-coding version thresholds (which distro
+# backports can invalidate -- e.g. AL2023 backports neoverse-v3 into GCC 11/14),
+# we probe the actual compiler and degrade gracefully:
+#   -march=armv9.2-a -> armv9-a (keeps required SVE2; loses SME/FEAT_MOPS).
+#                       If even armv9-a+sve2 is unsupported we error out, since
+#                       a working graviton5 binary requires SVE2.
+#   -mtune=neoverse-v3 -> neoverse-v2 -> omitted. Tuning only affects scheduling,
+#                       never correctness, so it is dropped if unsupported.
+# For best performance use a toolchain new enough for armv9.2-a + neoverse-v3
+# (upstream: roughly GCC >= 13 for the arch and Clang >= 19 / GCC >= 14 for the
+# tune model; your toolchain may differ).
 CFLAGS=""
 case "$TARGET_PLATFORM" in
     graviton2)
@@ -44,6 +72,35 @@ case "$TARGET_PLATFORM" in
         ;;
     graviton4)
         CFLAGS="-march=armv9-a+crypto+fp16+rcpc+dotprod+sve2 -mtune=neoverse-v2"
+        ;;
+    graviton5)
+        # -march sets the target ISA and is correctness-critical (must keep +sve2).
+        # Prefer armv9.2-a, fall back to armv9-a, and hard-error if neither works
+        # rather than emitting flags the compiler will later reject.
+        if compiler_accepts_flags -march=armv9.2-a+crypto+fp16+rcpc+dotprod+sve2; then
+            G5_MARCH="-march=armv9.2-a+crypto+fp16+rcpc+dotprod+sve2"
+        elif compiler_accepts_flags -march=armv9-a+crypto+fp16+rcpc+dotprod+sve2; then
+            echo "WARNING: ${CC} does not support -march=armv9.2-a; falling back to armv9-a (graviton4-equivalent arch)."
+            G5_MARCH="-march=armv9-a+crypto+fp16+rcpc+dotprod+sve2"
+        else
+            echo "Error: ${CC} cannot target the Graviton5 ISA (needs at least -march=armv9-a+sve2)." >&2
+            echo "       Use a newer compiler (GCC >= 12 or Clang >= 15)." >&2
+            exit 1
+        fi
+        # -mtune only affects scheduling, never correctness, so probe each fallback
+        # and simply omit -mtune if none is supported (e.g. Clang < 16 has no
+        # neoverse-v2). This keeps older compilers building rather than emitting an
+        # unsupported -mtune value that fails much later in a dependency's build.
+        if compiler_accepts_flags -march=armv8-a -mtune=neoverse-v3; then
+            G5_MTUNE="-mtune=neoverse-v3"
+        elif compiler_accepts_flags -march=armv8-a -mtune=neoverse-v2; then
+            echo "WARNING: ${CC} does not support -mtune=neoverse-v3; falling back to neoverse-v2."
+            G5_MTUNE="-mtune=neoverse-v2"
+        else
+            echo "WARNING: ${CC} supports neither neoverse-v3 nor neoverse-v2 tuning; omitting -mtune."
+            G5_MTUNE=""
+        fi
+        CFLAGS="${G5_MARCH}${G5_MTUNE:+ $G5_MTUNE}"
         ;;
     avx2)
         CFLAGS="-march=haswell -mtune=haswell"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Fix overly-restrictive x265 ARM assembly gate
- Add Graviton5 target platform support
- Fix aom build with nasm 3.x (Ubuntu resolute) 
- Update x265 repo URL to GitHub

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
