### PR TITLE
perfrunbook/configuring_your_sut.md: fix invalid rustc flag -Ctarget-features -> -Ctarget-feature

### DIFF
--- a/perfrunbook/configuring_your_sut.md
+++ b/perfrunbook/configuring_your_sut.md
@@ -140,7 +140,7 @@ For native compiled components of your application, proper compile flags are ess
     1. Use `-moutline-atomics` for code that must run on all Graviton platforms
     2. Use `-march=armv8.2-a -mcpu=neoverse-n1` for code that will run on Graviton2 or later and other modern Arm platforms
 3. When building natively for Rust, ensure that `RUSTFLAGS` is set to **one of the following flags**
-    1. `export RUSTFLAGS="-Ctarget-features=+lse"` for code that will run on all Graviton2 and other Arm platforms that support LSE (Large System Extension) instructions.
+    1. `export RUSTFLAGS="-Ctarget-feature=+lse"` for code that will run on all Graviton2 and other Arm platforms that support LSE (Large System Extension) instructions.
     2. `export RUSTFLAGS="-Ctarget-cpu=neoverse-n1"` for code that will only run on Graviton2 and later platforms.
 4. Check for the existence of assembly optimized on x86 with no optimization on Graviton.  For help with porting optimized assembly routines, see [Section 6](./optimization_recommendation.md).
   ```bash


### PR DESCRIPTION
*Summary:*

The Rust build example in `configuring_your_sut.md` uses an invalid `rustc`
codegen flag. The correct option is `-C target-feature` (singular), not
`-Ctarget-features` (plural).

`rustc` exposes the codegen option as `-C target-feature`. Passing the plural
form fails:
```
$ rustc -Ctarget-features=+lse main.rs
error: unknown codegen option: `target-features`
```

rustc codegen options reference, `target-feature`:
  https://doc.rust-lang.org/rustc/codegen-options/index.html#target-feature
  (documents `-C target-feature=+lse`; there is no `target-features` option)

*Issue #, if available:*
N/A

*Description of changes:*

Single-character fix (removed the trailing `s`); no other lines touched.
`1 file changed, 1 insertion(+), 1 deletion(-)`.

```diff
-    1. `export RUSTFLAGS="-Ctarget-features=+lse"` for code that will run on all Graviton2 ...
+    1. `export RUSTFLAGS="-Ctarget-feature=+lse"` for code that will run on all Graviton2 ...
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
