### PR TITLE
perfrunbook: fix ethtool typo `adpative-rx` -> `adaptive-rx`

### DIFF
--- a/perfrunbook/optimization_recommendation.md
+++ b/perfrunbook/optimization_recommendation.md
@@ -52,7 +52,7 @@ allocating huge-pages.
 ## Network heavy workload optimizations
 
 1. Check ENA device tunings with `ethtool -c ethN` where `N` is the device number and check `Adaptive RX` setting. By default on instances without extra ENI’s this will be `eth0`.
-    1. Set to `ethtool -C ethN adpative-rx off` for a latency sensitive workload
+    1. Set to `ethtool -C ethN adaptive-rx off` for a latency sensitive workload
     2. ENA tunings via `ethtool` can be made permanent by editing `/etc/sysconfig/network-scripts/ifcfg-ethN` files.
 2. Disable `irqbalance` from dynamically moving IRQ processing between vCPUs and set dedicated cores to process each IRQ.  Example script below:
   ```bash


### PR DESCRIPTION
*Summary:*


The ethtool interrupt-coalescing example in `optimization_recommendation.md`
misspells the `adaptive-rx` keyword as `adpative-rx` (transposed `p`/`a`).

`ethtool -C` accepts `adaptive-rx on|off` (and `adaptive-tx on|off`) per the
ethtool(8) man page. The misspelled `adpative-rx` is not a recognized parameter,
so the documented command is rejected:
```
$ ethtool -C eth0 adpative-rx off
ethtool: bad parameter adpative-rx
```

*Issue #, if available:*
N/A

*Description of changes:*

Single typo fix; no other lines touched. (Only one occurrence of the misspelling
in the file.) `1 file changed, 1 insertion(+), 1 deletion(-)`.

```diff
-    1. Set to `ethtool -C ethN adpative-rx off` for a latency sensitive workload
+    1. Set to `ethtool -C ethN adaptive-rx off` for a latency sensitive workload
```

ethtool(8) man page (documents `adaptive-rx`/`adaptive-tx` for `-C`):
  https://man7.org/linux/man-pages/man8/ethtool.8.html


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
