### PR TITLE
perfrunbook/utilities: fix SVE scale factor for Graviton4 in measure_aggregated_pmu_stats.py

### DIFF
--- a/perfrunbook/utilities/measure_aggregated_pmu_stats.py
+++ b/perfrunbook/utilities/measure_aggregated_pmu_stats.py
@@ -629,7 +629,7 @@ counter_mapping = {
         ArmCounterPKC("inst-sve-partial-pkc", "SVE_PRED_PARTIAL_SPEC", "event=0x8077"),
         # SCALE OPS: number of SVE ops, counting size of vector
         # See The A-profile achitecture reference manual (DDI 0487J.a) in Sec D12.11.1 tells us these are in ALU operations per 128-bits,
-        ArmCounterPKC("flop-sve-pkc", "FP_SCALE_OPS_SPEC", "event=0x80C0", scale=256/128),
+        ArmCounterPKC("flop-sve-pkc", "FP_SCALE_OPS_SPEC", "event=0x80C0", scale=128/128),
         # FP FIXED OPS: number of NEON and Scalar ops, counting NEON vector width (128-bit)
         ArmCounterPKC("flop-nonsve-pkc", "FP_FIXED_OPS_SPEC", "event=0x80C1"),
     ],


### PR DESCRIPTION
*Summary:*

Fix an incorrect SVE FLOP scale factor for Graviton4 in the PMU aggregation
script. The `flop-sve-pkc` metric currently over-reports Graviton4 scalable
floating-point throughput by 2x.

The script derives scalable-FP throughput from the `FP_SCALE_OPS_SPEC` PMU event
(event `0x80C0`). The Arm Architecture Reference Manual for A-profile
(DDI 0487 M.b, §D14, p. D14-8128) defines this event as:

> `0x80C0, FP_SCALE_OPS_SPEC` — Scalable element arithmetic operations
> speculatively executed, floating-point.
> The counter increments by **v** for each speculatively executed scalable
> element arithmetic operation, due to an instruction where the type was
> floating-point. Where **v** is a value such that **(v × (VL ÷ 128))** is the
> number of arithmetic operations carried out by the operation or instruction
> which causes the counter to increment.

So the raw counter value is deliberately normalized to be **independent of the
vector length** (it counts in 128-bit granules), and the true operation count is:

```
actual_ops = raw_count × (VL / 128)
```

The per-core scale factor in the script is therefore exactly
`scale = native_SVE_vector_width / 128`:

| Core | Graviton | SVE vector width | Correct scale |
|------|----------|------------------|---------------|
| Neoverse V1 | Graviton3 | 256-bit (2x256) | `256/128` = 2 |
| Neoverse V2 | Graviton4 | 128-bit (4x128, SVE2) | `128/128` = 1 |

The Graviton4 entry incorrectly used `256/128`. Neoverse V2 (Graviton4) has
**128-bit** SVE2 vectors, not 256-bit, so per the formula above the factor must
be `128/128`.

With the wrong factor, `flop-sve-pkc` reports 2x the actual SVE floating-point
operation rate on all Graviton4 instances (c8g, m8g, r8g, c8gn, etc.). The
Graviton3 entry (`256/128`) is correct under the same formula and is unchanged.

*Issue #, if available:*

N/A

*Description of changes:*

Single-line change to the Graviton4 entry only. The Graviton3 entry (correctly
`256/128`) is left untouched.

```diff
-    ArmCounterPKC("flop-sve-pkc", "FP_SCALE_OPS_SPEC", "event=0x80C0", scale=256/128),
+    ArmCounterPKC("flop-sve-pkc", "FP_SCALE_OPS_SPEC", "event=0x80C0", scale=128/128),
```

*How I verified*

-  Arm Architecture Reference Manual for A-profile, DDI 0487 M.b, §D14, p. D14-8128 — definition of
  `FP_SCALE_OPS_SPEC` (`actual_ops = raw_count × (VL/128)`).
  https://developer.arm.com/documentation/ddi0487/latest/
- Arm Neoverse V1 product page (2x 256-bit SVE units):
  https://www.arm.com/products/silicon-ip-cpu/neoverse/neoverse-v1
- Neoverse V2 SVE2 4x128 configuration (NVIDIA Grace CPU benchmarking guide,
  vectorization table):
  https://nvidia.github.io/grace-cpu-benchmarking-guide/developer/vectorization.html
- `FP_SCALE_OPS_SPEC` event listing (Arm PMU event data):
  https://github.com/ARM-software/data/blob/master/pmu/neoverse-v2.json

*Measured on Graviton4*

Confirmed on a `c8g.medium` (Graviton4) instance running Amazon
Linux 2023 (arm64):

```text
# SVE vector length
$ cat /proc/sys/abi/sve_default_vector_length
16                       # 16 bytes = 128 bits

# Known-FLOP SVE microbenchmark: 2e9 FP64 FMLA instructions.
# VL=128 -> 2 FP64 elements/vector; FMLA = mul+add = 2 ops/element
#   => true ops = 2e9 * 2 elements * 2 = 8.0e9
$ perf stat -e r80c0 ./bench    # r80c0 = FP_SCALE_OPS_SPEC
N_FMLA=2000000000  VL_bytes=16  true_flops=8000000000
r80c0 raw count = 8,000,028,012
```

The raw `FP_SCALE_OPS_SPEC` count (8.000e9) equals the true operation count
(8.0e9) to within measurement noise, i.e. `scale = true_ops / raw ≈ 1.000`.
This matches the architectural formula `actual_ops = raw × (VL/128) = raw × 1`
for Graviton4, confirming the correct scale factor is `128/128` = 1 (not
`256/128`).

*Reproduction Source*


rdvl.c — read the hardware SVE vector length
```bash
#include <stdint.h>
#include <stdio.h>
int main(void){ uint64_t v; asm volatile("rdvl %0, #1":"=r"(v));
    printf("RDVL bytes=%lu bits=%lu\n", v, v*8); return 0; }

$ gcc -O2 -march=armv8-a+sve rdvl.c -o rdvl && ./rdvl   # -> bits=128 on Graviton4
```
bench.c — 2e9 full-width FP64 SVE FMLA instructions*
```bash
#include <stdint.h>
#include <stdio.h>
int main(void){
    uint64_t v; asm volatile("rdvl %0, #1":"=r"(v));
    const uint64_t N = 2000000000ULL;              /* 2e9 FMLA */
    asm volatile(
        "ptrue p0.d\n  fmov z0.d, #1.0\n  fmov z1.d, #1.0\n  fmov z2.d, #1.0\n"
        "mov x0, %0\n 1:\n  fmla z0.d, p0/m, z1.d, z2.d\n"
        "  subs x0, x0, #1\n  b.ne 1b\n"
        :: "r"(N) : "x0","z0","z1","z2","p0","cc");
    /* VL/8 FP64 elements per vector; FMLA = 2 ops/element */
    printf("N_FMLA=%llu VL_bytes=%lu true_flops=%llu\n",
           (unsigned long long)N, v, (unsigned long long)(N*(v/8)*2));
    return 0; }

$ gcc -O2 -march=armv8-a+sve bench.c -o bench

# r80c0 = FP_SCALE_OPS_SPEC; compare the raw count to the printed true_flops
perf stat -e r80c0 ./bench
```

I created the above test based on Arm ARM DDI0487 and examples in https://nvidia.github.io/grace-cpu-benchmarking-guide/foundations/FMA/index.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
