### PR TITLE
perfrunbook/appendix.md: remove stray backticks breaking the eBPF install code block

### DIFF
--- a/perfrunbook/appendix.md
+++ b/perfrunbook/appendix.md
@@ -96,11 +96,11 @@ If you find a specific function that is mis-behaving, either putting the CPU to 
 1. Install the BCC tools
   ```bash
   # AL2 
-  %> sudo `amazon-linux-extras enable BCC
+  %> sudo amazon-linux-extras enable BCC
   %> sudo yum install bcc
     
   # Ubuntu
-  %> sudo apt-get install linux-headers-$(uname -r) bpfcc-tools`
+  %> sudo apt-get install linux-headers-$(uname -r) bpfcc-tools
   ```
 2. Write an eBPF program in C that can be embedded in a python file
 3. Run the eBPF program using the python to interface via the BCC tools and collect the statistics


### PR DESCRIPTION
*Summary:*

The eBPF / BCC install instructions in `appendix.md` contain two stray backtick
characters that turn the shell snippet into an (unintended) command
substitution. Anyone copy-pasting the commands hits a shell syntax error.

Inside the install code block, a stray `` ` `` precedes `amazon-linux-extras`
and a matching stray `` ` `` follows `bpfcc-tools`. In the shell, the first
backtick opens a command substitution and the second closes it, so everything
between them (the `yum install`, the Ubuntu comment, and the `apt-get` line) is
swallowed into a single backtick-expression and executed incorrectly.

*Issue #, if available:*
N/A

*Description of changes:*

Two stray backticks removed (`appendix.md`, 1 file, +2/−2). No commands,
package names, or other content changed; the code fences are left intact.

```diff
-  %> sudo `amazon-linux-extras enable BCC
+  %> sudo amazon-linux-extras enable BCC
...
-  %> sudo apt-get install linux-headers-$(uname -r) bpfcc-tools`
+  %> sudo apt-get install linux-headers-$(uname -r) bpfcc-tools
```

Documentation-only. No code paths or scripts are affected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
