### PR TITLE
perfrunbook/utilities: fix shutdown argument order (shutdown -r now)

### DIFF
--- a/perfrunbook/utilities/configure_graviton_metal_iommu.sh
+++ b/perfrunbook/utilities/configure_graviton_metal_iommu.sh
@@ -57,4 +57,4 @@ case $1 in
     exit 1
 esac
 
-echo "To make changes take effect run: %> sudo shutdown now -r"
+echo "To make changes take effect run: %> sudo shutdown -r now"

--- a/perfrunbook/utilities/configure_mem_size.sh
+++ b/perfrunbook/utilities/configure_mem_size.sh
@@ -37,4 +37,4 @@ cp $grub_loc ${grub_loc}.bak
 config_mem $1
 update_grub
 
-echo "To make changes take effect run: %> sudo shutdown now -r"
+echo "To make changes take effect run: %> sudo shutdown -r now"


### PR DESCRIPTION
*Summary*

Two utility scripts (`configure_graviton_metal_iommu.sh` and `configure_mem_side.sh`) invoke `shutdown` with the operands in the wrong order
(`shutdown now -r`). The reboot option `-r` must come before the `TIME` operand
(`shutdown -r now`), otherwise it can be interpreted as a wall message instead
of the reboot flag — causing the host to **halt/power off instead of reboot**.

*Issue #, if available:*
N/A

*Description of changes:*

Argument reorder only (2 files, +2/−2). No other flags, comments, or logic
changed.

```diff
# perfrunbook/utilities/configure_graviton_metal_iommu.sh
- sudo shutdown now -r
+ sudo shutdown -r now

# perfrunbook/utilities/configure_mem_size.sh
- sudo shutdown now -r
+ sudo shutdown -r now
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
