### PR TITLE
perfrunbook/debug_hw_perf.md: note Graviton4 uses 128-bit SVE2

### DIFF
--- a/perfrunbook/debug_hw_perf.md
+++ b/perfrunbook/debug_hw_perf.md
@@ -173,7 +173,7 @@ Backend stalls are caused when the CPU is unable to make forward progress execut
 
 ### Drill down Vectorization
 
-Vectorization is accomplished either by SVE or NEON instructions.  SVE vectorization will use 256-bit vectors on Graviton 3 processors, but the scalable nature of SVE makes both the code and binary vector-length agnostic.  NEON vectorization is always a 128-bit vector size, and does not have the predicate feature of SVE.
+Vectorization is accomplished either by SVE or NEON instructions.  SVE vectorization will use 256-bit vectors on Graviton 3 (Neoverse V1) processors and 128-bit vectors on Graviton 4 (Neoverse V2, SVE2), but the scalable nature of SVE makes both the code and binary vector-length agnostic.  NEON vectorization is always a 128-bit vector size, and does not have the predicate feature of SVE.
 
 For SVE instructions there are metrics which describe how many SVE instructions had empty, full and partially-filled SVE predicates: `inst-sve-empty-pkc`, `inst-sve-partial-pkc`, and `inst-sve-full-pkc`.  These metrics apply to all SVE instructions (loads, stores, integer, and floating-point operations).  The `pkc` term indicates the counters are in units of "per kilo cycle".
 

--- a/perfrunbook/debug_hw_perf.md
+++ b/perfrunbook/debug_hw_perf.md
@@ -173,7 +173,7 @@ Backend stalls are caused when the CPU is unable to make forward progress execut
 
 ### Drill down Vectorization
 
-Vectorization is accomplished either by SVE or NEON instructions.  SVE vectorization will use 256-bit vectors on Graviton 3 (Neoverse V1) processors and 128-bit vectors on Graviton 4 (Neoverse V2, SVE2), but the scalable nature of SVE makes both the code and binary vector-length agnostic.  NEON vectorization is always a 128-bit vector size, and does not have the predicate feature of SVE.
+Vectorization is accomplished either by SVE or NEON instructions.  SVE vectorization will use 256-bit vectors on Graviton3 (Neoverse V1) processors and 128-bit vectors on Graviton4 (Neoverse V2, SVE2), but the scalable nature of SVE makes both the code and binary vector-length agnostic.  NEON vectorization is always a 128-bit vector size, and does not have the predicate feature of SVE.
 
 For SVE instructions there are metrics which describe how many SVE instructions had empty, full and partially-filled SVE predicates: `inst-sve-empty-pkc`, `inst-sve-partial-pkc`, and `inst-sve-full-pkc`.  These metrics apply to all SVE instructions (loads, stores, integer, and floating-point operations).  The `pkc` term indicates the counters are in units of "per kilo cycle".
 


### PR DESCRIPTION
*Summary*

The SVE discussion in `debug_hw_perf.md` only states the vector width for
Graviton3 (256-bit) and omits Graviton4. This adds Graviton4's vector width
(128-bit SVE2) inline so the section is accurate for Graviton4.

*Issue #, if available:*
follow on update from #500 

*Description of changes:*

The existing sentence says SVE "will use 256-bit vectors on Graviton 3
processors" with no mention of Graviton4. Graviton4 (Arm Neoverse V2) implements
**SVE2 with a 128-bit vector length** — half the Graviton3 (Neoverse V1) width —
so a reader sizing or reasoning about SVE work on Graviton4 would be misled by
the current text.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
