### PR TITLE
perfrunbook/debug_hw_perf.md: add Graviton4 (CMN-700) CMN documentation

### DIFF
--- a/perfrunbook/debug_hw_perf.md
+++ b/perfrunbook/debug_hw_perf.md
@@ -295,3 +295,5 @@ Further information about capturing fabric events is available here:
 
 [ARM documentation for Graviton3's CMN-650](https://developer.arm.com/documentation/101481/0200/?lang=en)
 
+[ARM documentation for Graviton4's CMN-700](https://developer.arm.com/documentation/102308/latest/?lang=en)
+


### PR DESCRIPTION
*Summary:*

The CMN (Coherent Mesh Network) fabric-events section of debug_hw_perf.md links to the Arm CMN documentation for Graviton2 (CMN-600) and Graviton3 (CMN-650) but is missing the equivalent link for Graviton4 (CMN-700). This adds it.

*Issue #, if available:*
N/A

*Description of changes:*
Added link to [ARM documentation for Graviton4's CMN-700](https://developer.arm.com/documentation/102308/latest/?lang=en) in `debig_hw_perf.md` as linked in `perfrunbook/appendix.md` 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
