### PR TITLE
perfrunbook/utilities: match all RHEL 9.x releases (not just 9.5) in install script

### DIFF
--- a/perfrunbook/utilities/install_perfrunbook_dependencies.sh
+++ b/perfrunbook/utilities/install_perfrunbook_dependencies.sh
@@ -148,7 +148,7 @@ case "$os_name" in
   "Ubuntu 24.04"*)
     install_ubuntu2404_dependencies
     ;;
-  "Red Hat Enterprise Linux 9.5 (Plow)")
+  "Red Hat Enterprise Linux 9"*)
     install_rhel_9_5_dependencies
     ;;
   "SUSE Linux Enterprise Server 15 SP6")


### PR DESCRIPTION
*Summary:*

`utilities/install_perfrunbook_dependencies.sh` matches the RHEL OS string with
an exact literal `"Red Hat Enterprise Linux 9.5 (Plow)"`, so RHEL 9.6 and later
fall through unmatched and the dependencies are never installed. This switches
the match to a `9.x` glob.

The OS detection reads `PRETTY_NAME` from `/etc/os-release` and routes it through
a bash `case`:

```bash
os_name=$(cat /etc/os-release | grep "PRETTY_NAME" | awk -F"=" '{print $2}' | tr -d '[="=]' | tr -d [:cntrl:])
case "$os_name" in
  ...
  "Red Hat Enterprise Linux 9.5 (Plow)")   # exact, pinned to 9.5
    install_rhel_9_5_dependencies ;;
  ...
  *)
    echo "$os_name not supported"
    exit 1 ;;
esac
```

The RHEL pattern is pinned to the 9.5 point release, so any newer RHEL 9
(9.6, 9.7, 9.8, …) misses it and hits the `*)` default — the script prints
`Red Hat Enterprise Linux 9.x (Plow) not supported` and exits 1, so RHEL 9.6+
users cannot run the installer at all.

*Issue #, if available:*
N/A

*Description of changes:*

1 file changed, +1/−1. The existing RHEL handler/body is unchanged. The glob
matches all RHEL 9.x and does NOT match RHEL 10 (which begins
`…Enterprise Linux 10`).

```diff
- "Red Hat Enterprise Linux 9.5 (Plow)")
+ "Red Hat Enterprise Linux 9"*)
```

*Verification:*

Launched a **RHEL 9.8 aarch64** EC2 instance (`t4g.medium`) and evaluated the OS string — using
the script's own extraction — against both the old and new patterns:

```text
# os_name derived exactly as the script does:
#   os_name=$(cat /etc/os-release | grep "PRETTY_NAME" | awk -F"=" '{print $2}' | tr -d '[="=]' | tr -d [:cntrl:])
os_name=[Red Hat Enterprise Linux 9.8 (Plow)]
/etc/redhat-release: Red Hat Enterprise Linux release 9.8 (Plow)
arch: aarch64

===== OLD pattern (exact "9.5 (Plow)") =====
OLD_NOMATCH          # current code fails to match RHEL 9.8

===== NEW pattern (glob "Red Hat Enterprise Linux 9"*) =====
NEW_MATCH            # fix matches RHEL 9.8 (and all 9.x)
```

Because the old pattern does not match, RHEL 9.8 falls through to the script's
default branch:

```bash
*)
  echo "$os_name not supported"
  exit 1 ;;
```
so today the installer aborts with `Red Hat Enterprise Linux 9.8 (Plow) not
supported` on RHEL 9.6+. The glob fix routes it to the existing
`install_rhel_9_5_dependencies` handler instead. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
