### PR TITLE
perfrunbook: minor doc cleanup

### DIFF
--- a/perfrunbook/debug_hw_perf.md
+++ b/perfrunbook/debug_hw_perf.md
@@ -157,7 +157,7 @@ Front end stalls commonly occur if the CPU cannot fetch the proper instructions,
 3. Measure `inst-tlb-mpki`. A value >0 indicates the CPU has to do extra stalls to translate the virtual addresses of instructions into physical addresses before fetching them and the footprint is too large.
 4. Measure `inst-tlb-tw-pki` . A value >0 indicates the instruction footprint might be too large.
 5. Measure `code-sparsity` . A number >0.5 indicates the code being executed by the CPU is very sparse. This counter is only available on Graviton 16xlarge or metal instances. If the number is >0.5 for the workload under test please see [Optimizing For Large Instruction Footprints](./optimization_recommendation.md#optimizing-for-large-instruction-footprint).
-5. If front-end stalls are the root cause, the instruction footprint needs to be made smaller, proceed to [Section 6](./optimization_recommendation.md) for suggestions on how to reduce front end stalls for your application..
+6. If front-end stalls are the root cause, the instruction footprint needs to be made smaller, proceed to [Section 6](./optimization_recommendation.md) for suggestions on how to reduce front end stalls for your application.
 
 ### Drill down back-end stalls
 

--- a/perfrunbook/debug_system_perf.md
+++ b/perfrunbook/debug_system_perf.md
@@ -15,7 +15,7 @@ When debugging performance, start by measuring high level system behavior to pin
   %> cd ~/aws-graviton-getting-started/perfrunbook/utilities
   %> python3 ./measure_and_plot_basic_sysstat_stats.py --stat cpu-iowait --time 60
   ```
-2. Check the `cpu-user` and `cpu-kernel` time at your chosen load point. Check to see if Graviton2 has higher or lower cpu time  than the x86 comparison system-under-test.  
+2. Check the `cpu-user` and `cpu-kernel` time at your chosen load point. Check to see if Graviton has higher or lower cpu time  than the x86 comparison system-under-test.  
   ```bash
   # Terminal one
   %> <start load generator or benchmark>


### PR DESCRIPTION
*Summary:*

Two small, cosmetic documentation fixes. No technical/behavioral content
changes — purely formatting and wording.

*Issue #, if available:*
N/A

*Description of changes:*

1. `debug_hw_perf.md` — duplicate list number + double period
In the "Drill down front end stalls" list, two consecutive items were both
numbered `5.`, and the second item ended with a stray double period (`..`).

```diff
  5. Measure `code-sparsity` . A number >0.5 indicates the code being executed by the CPU is very sparse. ...
- 5. If front-end stalls are the root cause, ... to reduce front end stalls for your application..
+ 6. If front-end stalls are the root cause, ... to reduce front end stalls for your application.
```
(No further renumbering needed — the next section starts a fresh list at 1.)

2. `debug_system_perf.md` — generic "Graviton" wording (line 18)
This sentence is generic performance-comparison guidance that applies to any
Graviton generation, but said "Graviton2" specifically.

```diff
- Check to see if Graviton2 has higher or lower cpu time than the x86 comparison system-under-test.
+ Check to see if Graviton has higher or lower cpu time than the x86 comparison system-under-test.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
