### PR TITLE
perfrunbook/utilities: fix Ubuntu 24.04 python deps install (pipx -> pip --break-system-packages)

### DIFF
--- a/perfrunbook/utilities/install_perfrunbook_dependencies.sh
+++ b/perfrunbook/utilities/install_perfrunbook_dependencies.sh
@@ -72,9 +72,8 @@ install_ubuntu2404_dependencies () {
   apt-get install -y -q linux-tools-$(uname -r) linux-headers-$(uname -r) linux-modules-extra-$(uname -r) bpfcc-tools
 
   echo "------ INSTALL ANALYSIS TOOLS AND DEPENDENCIES ------"
-  apt-get install -y -q python3-dev python3-pip pipx
-  pipx install pandas numpy scipy matplotlib sh seaborn plotext --include-deps
-  pipx ensurepath
+  apt-get install -y -q python3-dev python3-pip
+  python3 -m pip install --break-system-packages pandas numpy scipy matplotlib sh seaborn plotext
   git clone https://github.com/brendangregg/FlameGraph.git FlameGraph
 
   echo "------ DONE ------"


### PR DESCRIPTION
*Summary:*

The Ubuntu 24.04 path installs the Python libraries with `pipx`, which manages
isolated CLI apps (one package per invocation) and leaves the libraries
un-importable — so the perfrunbook utilities run without their dependencies.
Switch to `python3 -m pip install --break-system-packages …`, matching every
other distro path.

`pipx install pandas numpy scipy matplotlib sh seaborn plotext` fails on
Ubuntu 24.04 (verified below): pipx isn't for libraries. The 
alternative `python3 -m pip install`, as the other distros use is
blocked by PEP 668 (externally-managed). apt can't cover the set
(`python3-plotext` isn't in Noble), and a venv would break the utilities'
`#!/usr/bin/env python3` system-Python invocation. `--break-system-packages` is
the minimal fix that keeps Ubuntu 24.04 consistent with the other distro paths.

*Issue #, if available:*
N/A

*Description of changes:*

Only the `install_ubuntu2404_dependencies` function changed (1 file, +2/−3).
Same package list; no other distro path touched.

```diff
- apt-get install -y -q python3-dev python3-pip pipx
- pipx install pandas numpy scipy matplotlib sh seaborn plotext --include-deps
- pipx ensurepath
+ apt-get install -y -q python3-dev python3-pip
+ python3 -m pip install --break-system-packages pandas numpy scipy matplotlib sh seaborn plotext
```

*Verification:*

Ubuntu 24.04.4 LTS, aarch64 (`t4g.medium`), Python 3.12.3:

```text
===== (A) CURRENT: pipx install <multiple libraries> =====
pipx_run_exit=1
# pipx treats each arg as a separate app; pandas/sh/seaborn/plotext are NOT
# installed as importable libraries (pipx is for CLI apps, one package each).

===== (B) plain pip (what other distros use) =====
pip_plain_exit=1
error: externally-managed-environment
  ... You can override this ... by passing --break-system-packages.   # PEP 668

===== (C1) FIX: pip --break-system-packages =====
pip_bsp_exit=0
Successfully installed ... matplotlib-3.11.0 numpy-2.5.0 pandas-3.0.3
  scipy-1.18.0 seaborn-0.13.2 sh-2.3.0 plotext-5.3.2
BSP_IMPORTS_OK pandas 3.0.3 numpy 2.5.0      # all 7 import cleanly

===== (C3) apt availability =====
python3-pandas/numpy/scipy/matplotlib/sh/seaborn = available
python3-plotext = NOT AVAILABLE               # so apt alone can't be used
```

The fix (`--break-system-packages`) installed all seven packages and confirmed
they import.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
