### PR TITLE
perfrunbook/appendix.md: add Amazon Linux 2023 BCC/eBPF install path

### DIFF
--- a/perfrunbook/appendix.md
+++ b/perfrunbook/appendix.md
@@ -98,6 +98,9 @@ If you find a specific function that is mis-behaving, either putting the CPU to 
   # AL2 
   %> sudo amazon-linux-extras enable BCC
   %> sudo yum install bcc
+
+  # AL2023
+  %> sudo dnf install bcc
     
   # Ubuntu
   %> sudo apt-get install linux-headers-$(uname -r) bpfcc-tools


### PR DESCRIPTION
*Summary:*

The eBPF/BCC install instructions in `appendix.md` only cover AL2 (via
`amazon-linux-extras`) and Ubuntu. AL2 has no `amazon-linux-extras` successor on
AL2023, leaving AL2023 users with no documented path. This adds the AL2023
one-liner.

*Issue #, if available:*
N/A

*Description of changes:*

The AL2 path uses `amazon-linux-extras enable BCC` + `yum install bcc`, neither
of which exists on AL2023 (no `amazon-linux-extras`; `dnf` instead of `yum`). On
AL2023, BCC is packaged directly and installs with `sudo dnf install bcc`.

1 file changed, +3 lines. AL2 and Ubuntu blocks unchanged; same formatting.

```diff
   # AL2
   %> sudo amazon-linux-extras enable BCC
   %> sudo yum install bcc
+
+  # AL2023
+  %> sudo dnf install bcc
   # Ubuntu
   %> sudo apt-get install linux-headers-$(uname -r) bpfcc-tools
```

*Verification:*

Amazon Linux 2023 (`2023.12…`), kernel `6.1.175-219.359.amzn2023.aarch64`,
aarch64 (`t4g.medium`):

```text
$ sudo dnf install -y bcc
... Complete!                       
Installed: bcc-0.35.0-4.amzn2023.0.2.aarch64

$ ls /usr/share/bcc/tools
biolatency  biosnoop  execsnoop  opensnoop  ...   

$ sudo /usr/share/bcc/tools/execsnoop      # smoke test ran successfully
```
`sudo dnf install bcc` installs cleanly and provides the BCC tools under
`/usr/share/bcc/tools/`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
