### PR TITLE
 perfrunbook/configuring_your_sut.md: add AL2023 OS-check and package-update steps alongside AL2

### DIFF
--- a/perfrunbook/configuring_your_sut.md
+++ b/perfrunbook/configuring_your_sut.md
@@ -14,6 +14,10 @@ If you have more than one SUT, first verify there are no major differences in se
   %> sudo cat /etc/system-release
   Amazon Linux release 2 (Karoo)
     
+  ## Amazon Linux 2023
+  %> cat /etc/system-release
+  Amazon Linux release 2023.12.20260629 (Amazon Linux)
+    
   ## Ubuntu
   %> sudo lsb_release -a
   Distributor ID: Ubuntu
@@ -25,6 +29,9 @@ If you have more than one SUT, first verify there are no major differences in se
   ```bash
   ## AL2
   %> sudo yum update
+    
+  ## Amazon Linux 2023
+  %> sudo dnf update
     
   ## Ubuntu
   %> sudo apt-get upgrade


### PR DESCRIPTION
*Summary:*

Steps 1 (OS identification) and 2 (package update) only showed Amazon Linux 2
(`yum`) examples, while step 3 (kernel) was already modernized to Amazon Linux
2023 (`dnf`). This adds Amazon Linux 2023 examples to steps 1 and 2 **alongside
the existing AL2 examples** (AL2 instructions are retained), so the early steps
cover both and are consistent with step 3.


*Issue #, if available:*
N/A

*Description of changes:*

1 file changed, +7 lines, no deletions. AL2 and Ubuntu instructions are
unchanged.

```diff
 1. Check all instances are running the same OS distribution:
   ```bash
   ## AL2
   %> sudo cat /etc/system-release
   Amazon Linux release 2 (Karoo)
+
+  ## Amazon Linux 2023
+  %> cat /etc/system-release
+  Amazon Linux release 2023.12.20260629 (Amazon Linux)
   ## Ubuntu
   ...
 2. Update your system packages ...
   ```bash
   ## AL2
   %> sudo yum update
+
+  ## Amazon Linux 2023
+  %> sudo dnf update
   ## Ubuntu
   %> sudo apt-get upgrade
```

The added AL2023 examples follow the conventions already used in step 3's AL2023
kernel guidance:
- **"Amazon Linux 2023" label** (spelled out, matching step 3).
- **Concrete example output** — step 3 shows a concrete versioned string
  (`6.1.84-99.169.amzn2023.aarch64`), so step 1 shows the real versioned
  `/etc/system-release` output rather than a generic placeholder.
- **`dnf update`** — matches step 3's `sudo dnf update kernel` verb.

*Verification:*

Amazon Linux 2023, kernel `6.1.175-219.359.amzn2023.aarch64`, aarch64
(`t4g.medium`):
```text
$ cat /etc/system-release
Amazon Linux release 2023.12.20260629 (Amazon Linux)

$ . /etc/os-release; echo "$PRETTY_NAME"
Amazon Linux 2023.12.20260629

$ command -v dnf yum; ls -l "$(command -v yum)"
/usr/bin/dnf
/usr/bin/yum
/usr/bin/yum -> dnf-3         

$ sudo dnf check-update       
```
Notes: `/etc/system-release` on AL2023 carries a date-stamped build version
(used verbatim in the example). `yum` still works on AL2023 as a symlink to
`dnf`, but `dnf` is the canonical command and matches the kernel section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
