### PR TITLE
perfrunbook/optimization_recommendation.md: modernize ethtool persistence guidance (systemd-networkd/NetworkManager)

### DIFF
--- a/perfrunbook/optimization_recommendation.md
+++ b/perfrunbook/optimization_recommendation.md
@@ -53,7 +53,7 @@ allocating huge-pages.
 
 1. Check ENA device tunings with `ethtool -c ethN` where `N` is the device number and check `Adaptive RX` setting. By default on instances without extra ENI’s this will be `eth0`.
     1. Set to `ethtool -C ethN adaptive-rx off` for a latency sensitive workload
-    2. ENA tunings via `ethtool` can be made permanent by editing `/etc/sysconfig/network-scripts/ifcfg-ethN` files.
+    2. ENA `ethtool` tunings can be made persistent across reboots; the legacy `/etc/sysconfig/network-scripts/ifcfg-ethN` files no longer apply on Amazon Linux 2023, RHEL 9, or Ubuntu. Amazon Linux 2023 and Ubuntu use `systemd-networkd`: place a custom `.link` file in `/etc/systemd/network/` and set the equivalent options in its `[Link]` section (e.g. `UseAdaptiveRxCoalesce=false`). On RHEL 9 (NetworkManager), use `nmcli connection modify <conn> ethtool.<property> <value>` (e.g. `ethtool.coalesce-adaptive-rx 0`).
 2. Disable `irqbalance` from dynamically moving IRQ processing between vCPUs and set dedicated cores to process each IRQ.  Example script below:
   ```bash
   # Assign eth0 ENA interrupts to the first N-1 cores


### PR DESCRIPTION
*Summary:*

The network-optimization section says ethtool tunings can be persisted by
editing `/etc/sysconfig/network-scripts/ifcfg-ethN`. That mechanism no longer
applies on the distros the perfrunbook targets (Amazon Linux 2023, RHEL 9,
Ubuntu). This replaces it with the correct, distro-appropriate methods.

- **Amazon Linux 2023** uses **`systemd-networkd`** as its network backend (per
  the AL2023 docs below). `amazon-ec2-net-utils`
  generates `.network` files in `/run/systemd/network`, which you override with
  custom drop-ins in `/etc/systemd/network/`. ethtool-level settings belong in a
  `.link` file `[Link]` section.
- **Ubuntu** likewise uses `systemd-networkd` (via netplan).
- **RHEL 9** uses **NetworkManager** with keyfile profiles; ethtool settings are
  applied via `nmcli connection modify <conn> ethtool.<property>`.
- The legacy `ifcfg`/`network-scripts` approach is deprecated and not present on
  any of these by default.

*Issue #, if available:*
N/A

*Description of changes:*

1 file changed, +1/−1 (one list item rewritten). The examples
(`UseAdaptiveRxCoalesce=false` / `ethtool.coalesce-adaptive-rx 0`) map to the
`adaptive-rx off` recommendation in the preceding list item.

```diff
-    2. ENA tunings via `ethtool` can be made permanent by editing `/etc/sysconfig/network-scripts/ifcfg-ethN` files.
+    2. ENA `ethtool` tunings can be made persistent across reboots; the legacy `/etc/sysconfig/network-scripts/ifcfg-ethN` files no longer apply on Amazon Linux 2023, RHEL 9, or Ubuntu. Amazon Linux 2023 and Ubuntu use `systemd-networkd`: place a custom `.link` file in `/etc/systemd/network/` and set the equivalent options in its `[Link]` section (e.g. `UseAdaptiveRxCoalesce=false`). On RHEL 9 (NetworkManager), use `nmcli connection modify <conn> ethtool.<property> <value>` (e.g. `ethtool.coalesce-adaptive-rx 0`).
```

*Verification:*

-  Amazon Linux 2023 uses `systemd-networkd`; `amazon-ec2-net-utils` generates `.network` files under
  `/run/systemd/network`, overridden by custom files in `/etc/systemd/network/`.
  https://docs.aws.amazon.com/linux/al2023/ug/networking-service.html
- `systemd.link(5)` `[Link]` section (`UseAdaptiveRxCoalesce`, `RxBufferSize`,
  `RxChannels`, offloads; coalescing supported since systemd v250):
  https://www.freedesktop.org/software/systemd/man/latest/systemd.link.html
- NetworkManager `ethtool.*` connection properties (RHEL 9), set via
  `nmcli connection modify`:
  https://networkmanager.dev/docs/api/latest/nm-settings-nmcli.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
