### PR TITLE
perfrunbook/utilities: install Python deps into a virtual environment

### DIFF
--- a/perfrunbook/configuring_your_loadgen.md
+++ b/perfrunbook/configuring_your_loadgen.md
@@ -51,7 +51,7 @@ The load generator setup is important to understand and verify: it generates the
    
    # Terminal on SUT
    %> cd ~/aws-graviton-getting-started/perfrunbook/utilities
-   %> python3 ./measure_and_plot_basic_sysstat_stats.py --stat new-connections --time 60
+   %> ./measure_and_plot_basic_sysstat_stats.py --stat new-connections --time 60
    ```
 9. If higher than expected connections/s are being observed, the cause of these new connections can be determined by looking at a packet trace and determining which end is initiating and closing the connections. 
    ```bash
@@ -74,8 +74,8 @@ The load generator setup is important to understand and verify: it generates the
     
    # Terminal #2 on load generator
    %> cd ~/aws-graviton-getting-started/perfrunbook/utilities
-   %> python3 ./measure_and_plot_basic_sysstat_stats.py --stat tcp-out-segments --time 60
-   %> python3 ./measure_and_plot_basic_sysstat_stats.py --stat tcp-in-segments --time 60
+   %> ./measure_and_plot_basic_sysstat_stats.py --stat tcp-out-segments --time 60
+   %> ./measure_and_plot_basic_sysstat_stats.py --stat tcp-in-segments --time 60
    ```
    Or, if you have an [APerf](https://github.com/aws/aperf) report, check the `IpExt:InOctets` and `IpExt:OutOctets` metrics in Network stats:
    ![Aperf report](images/aperf-examples/netstat_in_out_traffics.png)

--- a/perfrunbook/debug_hw_perf.md
+++ b/perfrunbook/debug_hw_perf.md
@@ -66,7 +66,7 @@ To measure the standard CPU PMU events, do the following:
   # In terminal 2
   %> cd ~/aws-graviton-getting-started/perfrunbook/utilities
   # AMD (5a, 6a and 7a) instances not supported currently.
-  %> sudo python3 ./measure_and_plot_basic_pmu_counters.py --stat ipc
+  %> sudo ./measure_and_plot_basic_pmu_counters.py --stat ipc
     
   # Example Output
   1.6 ++-----------------------+------------------------+------------------------+-----------------------+------------------------+-----------------------++
@@ -114,7 +114,7 @@ To measure the standard CPU PMU events, do the following:
   # In terminal 2
   %> cd ~/aws-graviton-getting-started/perfrunbook/utilities
   # AMD (5a, 6a, and 7a) instances not supported currently.
-  %> sudo python3 ./measure_aggregated_pmu_stats.py --timeout 300
+  %> sudo ./measure_aggregated_pmu_stats.py --timeout 300
 |Ratio               |   geomean|       p10|       p50|       p90|       p95|       p99|     p99.9|      p100|
 |ipc                 |      1.81|      1.72|      1.81|      1.90|      1.93|      1.95|      1.95|      1.95|
 |branch-mpki         |      0.01|      0.01|      0.01|      0.01|      0.01|      0.02|      0.02|      0.02|

--- a/perfrunbook/debug_system_perf.md
+++ b/perfrunbook/debug_system_perf.md
@@ -13,7 +13,7 @@ When debugging performance, start by measuring high level system behavior to pin
     
   # Terminal two
   %> cd ~/aws-graviton-getting-started/perfrunbook/utilities
-  %> python3 ./measure_and_plot_basic_sysstat_stats.py --stat cpu-iowait --time 60
+  %> ./measure_and_plot_basic_sysstat_stats.py --stat cpu-iowait --time 60
   ```
 2. Check the `cpu-user` and `cpu-kernel` time at your chosen load point. Check to see if Graviton has higher or lower cpu time  than the x86 comparison system-under-test.  
   ```bash
@@ -22,7 +22,7 @@ When debugging performance, start by measuring high level system behavior to pin
     
   # Terminal two
   %> cd ~/aws-graviton-getting-started/perfrunbook/utilities
-  %> python3 ./measure_and_plot_basic_sysstat_stats.py --stat cpu-user --time 60
+  %> ./measure_and_plot_basic_sysstat_stats.py --stat cpu-user --time 60
   # To get kernel time, do cpu-kernel
     
   # Example output
@@ -87,7 +87,7 @@ If you have an [APerf](https://github.com/aws/aperf) report, check the Memory Us
     
   # On SUT
   %> cd ~/aws-graviton-getting-started/perfrunbook/utilities
-  %> python3 ./measure_and_plot_basic_sysstat_stats.py --stat new-connections --time 60
+  %> ./measure_and_plot_basic_sysstat_stats.py --stat new-connections --time 60
   ```
 2. If seeing bursts, verify this is expected behavior for your load generator.  Bursts can cause performance degradation for each new connection, especially if it has to do an RSA signing operation for TLS connection establishment.
 3. Check on SUT for hot connections (connections that are more heavily used than others) by running: `watch netstat -t`

--- a/perfrunbook/utilities/install_perfrunbook_dependencies.sh
+++ b/perfrunbook/utilities/install_perfrunbook_dependencies.sh
@@ -1,5 +1,18 @@
 #!/bin/bash
 
+# The analysis utilities import their Python dependencies as libraries and are
+# shebang'd against this interpreter. We install those dependencies into a
+# dedicated virtual environment rather than the system interpreter: newer
+# distributions mark the system Python as externally-managed (PEP 668), and a
+# venv keeps the dependencies self-contained on every distribution.
+PERFRUNBOOK_VENV="/opt/perfrunbook-venv"
+
+install_python_dependencies () {
+  python3 -m venv "${PERFRUNBOOK_VENV}"
+  "${PERFRUNBOOK_VENV}/bin/pip" install --upgrade pip
+  "${PERFRUNBOOK_VENV}/bin/pip" install pandas numpy scipy matplotlib sh seaborn plotext
+}
+
 install_al2023_dependencies () {
   echo "------ INSTALLING UTILITIES ------"
   dnf install -y -q vim unzip git
@@ -12,8 +25,7 @@ install_al2023_dependencies () {
 
   echo "------ INSTALL ANALYSIS TOOLS AND DEPENDENCIES ------"
   dnf install -y -q python3 python3-pip
-  python3 -m pip install --upgrade pip
-  python3 -m pip install pandas numpy scipy matplotlib sh seaborn plotext
+  install_python_dependencies
   git clone https://github.com/brendangregg/FlameGraph.git FlameGraph
 
   echo "------ DONE ------"
@@ -31,8 +43,7 @@ install_al2_dependencies () {
 
   echo "------ INSTALL ANALYSIS TOOLS AND DEPENDENCIES ------"
   yum install -y -q python3 python3-pip
-  python3 -m pip install --upgrade pip
-  python3 -m pip install pandas numpy scipy matplotlib sh seaborn plotext
+  install_python_dependencies
   git clone https://github.com/brendangregg/FlameGraph.git FlameGraph
 
   echo "------ DONE ------"
@@ -51,9 +62,8 @@ install_ubuntu2004_dependencies () {
   apt-get install -y -q linux-tools-$(uname -r) linux-headers-$(uname -r) linux-modules-extra-$(uname -r) bpfcc-tools
 
   echo "------ INSTALL ANALYSIS TOOLS AND DEPENDENCIES ------"
-  apt-get install -y -q python3-dev python3-pip
-  python3 -m pip install --upgrade pip
-  python3 -m pip install pandas numpy scipy matplotlib sh seaborn plotext
+  apt-get install -y -q python3-dev python3-pip python3-venv
+  install_python_dependencies
   git clone https://github.com/brendangregg/FlameGraph.git FlameGraph
 
   echo "------ DONE ------"
@@ -72,9 +82,8 @@ install_ubuntu2404_dependencies () {
   apt-get install -y -q linux-tools-$(uname -r) linux-headers-$(uname -r) linux-modules-extra-$(uname -r) bpfcc-tools
 
   echo "------ INSTALL ANALYSIS TOOLS AND DEPENDENCIES ------"
-  apt-get install -y -q python3-dev python3-pip pipx
-  pipx install pandas numpy scipy matplotlib sh seaborn plotext --include-deps
-  pipx ensurepath
+  apt-get install -y -q python3-dev python3-pip python3-venv
+  install_python_dependencies
   git clone https://github.com/brendangregg/FlameGraph.git FlameGraph
 
   echo "------ DONE ------"
@@ -92,8 +101,7 @@ install_rhel_9_5_dependencies () {
 
   echo "------ INSTALL ANALYSIS TOOLS AND DEPENDENCIES ------"
   dnf install -y -q python3 python3-pip
-  python3 -m pip install --upgrade pip
-  python3 -m pip install pandas numpy scipy matplotlib sh seaborn plotext
+  install_python_dependencies
   git clone https://github.com/brendangregg/FlameGraph.git FlameGraph
 
   echo "------ DONE ------"
@@ -115,8 +123,7 @@ install_sles_15_sp6_dependencies() {
     echo "------ INSTALL ANALYSIS TOOLS AND DEPENDENCIES ------"
     # Install Python and pip
     zypper --quiet --non-interactive install python3 python3-pip
-    python3 -m pip install --upgrade pip
-    python3 -m pip install pandas numpy scipy matplotlib sh seaborn plotext
+    install_python_dependencies
 
     # Get FlameGraph tools
     git clone https://github.com/brendangregg/FlameGraph.git FlameGraph

--- a/perfrunbook/utilities/measure_aggregated_pmu_stats.py
+++ b/perfrunbook/utilities/measure_aggregated_pmu_stats.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/opt/perfrunbook-venv/bin/python3
 # -*- coding: utf-8 -*-
 
 import argparse

--- a/perfrunbook/utilities/measure_and_plot_basic_pmu_counters.py
+++ b/perfrunbook/utilities/measure_and_plot_basic_pmu_counters.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/opt/perfrunbook-venv/bin/python3
 # -*- coding: utf-8 -*-
 
 import argparse

--- a/perfrunbook/utilities/measure_and_plot_basic_sysstat_stats.py
+++ b/perfrunbook/utilities/measure_and_plot_basic_sysstat_stats.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/opt/perfrunbook-venv/bin/python3
 # -*- coding: utf-8 -*-
 
 import argparse

--- a/perfrunbook/utilities/mpstat_parse.py
+++ b/perfrunbook/utilities/mpstat_parse.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#!/opt/perfrunbook-venv/bin/python3
 
 import numpy as np
 import pandas as pd

--- a/perfrunbook/utilities/sar_parse.py
+++ b/perfrunbook/utilities/sar_parse.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/opt/perfrunbook-venv/bin/python3
 
 import re
 import sys


### PR DESCRIPTION
## Summary

The Ubuntu 24.04 path installs the perfrunbook Python dependencies with `pipx`, which manages isolated CLI applications rather than importable libraries, so the utilities run without their dependencies (`ModuleNotFoundError`). The other distributions install into the system interpreter with `python3 -m pip install`, which newer releases block under PEP 668 (`externally-managed-environment`).

This installs the dependencies into a dedicated virtual environment (`/opt/perfrunbook-venv`) on every supported distribution, through a shared `install_python_dependencies` helper, and points the utilities at that interpreter. It honors PEP 668 where it is enforced, keeps the dependencies self-contained, and gives every distribution a single uniform install-and-run process. The previously duplicated `pip install` block is now defined once.

This is an alternative to #507, which fixes only the Ubuntu 24.04 path using `--break-system-packages`: that resolves the 24.04 breakage but overrides the PEP 668 protection on the system interpreter, whereas a virtual environment keeps the dependencies isolated and applies the same fix uniformly across all supported distributions. Thanks to @catlike for identifying and thoroughly documenting the original `pipx` bug in #507.

## Changes

- `utilities/install_perfrunbook_dependencies.sh`: add a shared `install_python_dependencies` helper that builds `/opt/perfrunbook-venv` and installs the dependencies into it; route all six distribution paths through it; add `python3-venv` on the apt-based distributions; drop the broken `pipx` lines from the 24.04 path.
- `utilities/*.py` (5 files): point the shebang at `/opt/perfrunbook-venv/bin/python3`; mark `mpstat_parse.py` and `sar_parse.py` executable for consistency.
- docs (`debug_hw_perf.md`, `debug_system_perf.md`, `configuring_your_loadgen.md`): invoke the utilities directly (`./script.py`) instead of `python3 ./script.py`, so they run under the venv interpreter named in the shebang.

## Verification

Verified end-to-end on real Graviton (aarch64) EC2 instances. On each, the install script completes, the venv is created, all dependencies import from the venv, the system interpreter is left without them (isolation confirmed), and a representative utility runs via the documented invocation.

| Distribution | Install | venv built + deps isolated | Utility runs |
|---|---|---|---|
| Amazon Linux 2023 | pass | pass | pass |
| Amazon Linux 2 | pass | pass | pass |
| Ubuntu 20.04 | pass | pass | pass |
| Ubuntu 22.04 | pass | pass | pass |
| Ubuntu 24.04 | pass | pass | pass |
| RHEL 9 | pass | pass | pass |
| SLES 15 SP6 | unchanged (see below) | partial (see below) | partial (see below) |

## Note on SLES 15 SP6

On SLES 15 SP6 the default `python3` is 3.6, for which `matplotlib` (and transitively `seaborn`) no longer publish aarch64 wheels, so `pip` attempts a source build that fails. This is a pre-existing limitation on `main`, not a regression here:

| Package | `main` (system pip, py3.6) | This change (venv, py3.6) |
|---|---|---|
| numpy | installs | installs |
| pandas | installs | installs |
| scipy | installs | installs |
| matplotlib | fails to build | fails to build |
| seaborn | fails to build | fails to build |
| plotext | not reached | not reached |
| sh | not reached | not reached |

Verified on a real SLES 15 SP6 aarch64 instance: the set of packages that install and that fail is identical before and after this change. The venv migration relocates where the dependencies are installed; it does not change what SLES 15 SP6's Python 3.6 can install. Making SLES install the full set (e.g. building the venv from `python3.11`, available in the SLES repositories) is tracked separately.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.