### PR TITLE
Fix broken references to section overview page

### DIFF
--- a/HPC/setup-an-ec2-hpc-instance.md
+++ b/HPC/setup-an-ec2-hpc-instance.md
@@ -38,7 +38,7 @@ Currently Loaded Modulefiles:
  1) binutils/12.2.0   2) acfl/23.04.1   3) armpl/23.04.1
 ```
 
-After that, you need to install EFA driver which is not installed on an EC2 instance by default and [Open MPI](README.md#open-mpi).
+After that, you need to install EFA driver which is not installed on an EC2 instance by default and [Open MPI](./#open-mpi).
 ```
 # install EFA, Open MPI under /shared
 cd /shared/tools

--- a/Monitoring_Tools_on_Graviton.md
+++ b/Monitoring_Tools_on_Graviton.md
@@ -1,5 +1,7 @@
 # Monitoring tools for AWS Graviton
-Listed below are some monitoring and profiling tools supported on AWS Gravtion. Also listed are some differences when compared to the tools available on x86 processor architectures.
+We recommend using [APerf](https://github.com/aws/aperf) for all performance monitoring, debugging, and profiling tasks. It runs on Graviton, Intel, and AMD platforms. It collects a large variety of performance-related system metrics and profiles, performs analysis, and visualizes them in HTML-based reports.
+
+Other monitoring and profiling tools supported on AWS Gravtion are listed below, as well as differences when compared to the tools available on x86 platforms.
 
 Some of the most commonly used tools such as _top, htop, iostat, lstopo, hwloc, dmidecode, lmbench, Linux perf_ are supported on AWS Graviton processors. There are some tools such as Intel MLC, Intel VTune Profiler, PCM that are supported only on Intel processors and some tools such as _turbostat_ supported on x86 processors.
 

--- a/README.md
+++ b/README.md
@@ -26,16 +26,20 @@ This repository provides technical guidance for users and developers using [Amaz
 * [Third-party Software Vendors](isv.md)
 * [Finding and managing AMIs for Graviton, with AWS SystemManager or CloudFormation](amis_cf_sm.md)
 * [DPDK, SPDK, and other datapath software](dpdk_spdk.md)
-* [PyTorch](machinelearning/pytorch.md)
-* [llama.cpp](machinelearning/llama.cpp.md)
+* Machine Learning
+	* [PyTorch](machinelearning/pytorch.md)
+	* [llama.cpp](machinelearning/llama.cpp.md)
+	* [TensorFlow](machinelearning/tensorflow.md)
+	* [vLLM](machinelearning/vllm.md)
+	* [ONNX](machinelearning/onnx.md)
 * [R](R.md)
-* [TensorFlow](machinelearning/tensorflow.md)
 * [Spark on Graviton](DataAnalytics.md)
+* [HPC (High Performance Computing)](HPC/)
 * [Known issues and workarounds](#known-issues-and-workarounds)
 * [AWS Managed Services available on Graviton](managed_services.md)
-* [Graviton Performance Runbook](perfrunbook/README.md)
+* [Graviton Performance Runbook](perfrunbook/)
 * [Assembly Optimization Guide for Graviton Arm64 Processors](arm64-assembly-optimization.md)
-* [Tools and Agent Skills](tools/README.md)
+* [Tools and Agent Skills](tools/)
 * [Additional resources](#additional-resources)
 * [How To Resources](howtoresources.md)
 * [Blog Posts](#blog-posts)
@@ -72,7 +76,7 @@ DRAM	|8x DDR4	|8x DDR5	|12x DDR5 (24x for 48xlarge) | 12x DDR5 |
 DDR Encryption	|yes	|yes	|yes |yes |
 
 # Optimizing for Graviton
-Please refer to [optimizing](optimizing.md) for general debugging and profiling information.  For detailed checklists on optimizing and debugging performance on Graviton, see our [performance runbook](perfrunbook/README.md).
+Please refer to [optimizing](optimizing.md) for general debugging and profiling information.  For detailed checklists on optimizing and debugging performance on Graviton, see our [performance runbook](perfrunbook/).
 
 Different architectures and systems have differing capabilities, which means some tools you might be familiar with on one architecture don't have equivalent on AWS Graviton. Documented [Monitoring Tools](Monitoring_Tools_on_Graviton.md) with some of these utilities.
 
@@ -102,7 +106,7 @@ Package | Version | Improvements
 --------|:-:|-------------
 bazel	| [3.4.1+](https://github.com/bazelbuild/bazel/releases) | Pre-built bazel binary for Graviton/Arm64. [See below](#bazel-on-linux) for installation.
 Cassandra | 4.0+ | Supports running on Java/Corretto 11, improving overall performance
-FFmpeg  | 6.0+ | Improvements to scaling and improvements for codec libraries including `libaom`, `libx265`. We recommend [building FFmpeg from source](video-encoding/ffmpeg-build/README.md) with latest codec releases. For more information about FFmpeg on Graviton, read the blog post on AWS Open Source Blog, [Video Encoding on Graviton in 2025](https://aws.amazon.com/blogs/opensource/video-encoding-on-graviton-in-2025/).
+FFmpeg  | 6.0+ | Improvements to scaling and improvements for codec libraries including `libaom`, `libx265`. We recommend [building FFmpeg from source](video-encoding/ffmpeg-build/) with latest codec releases. For more information about FFmpeg on Graviton, read the blog post on AWS Open Source Blog, [Video Encoding on Graviton in 2025](https://aws.amazon.com/blogs/opensource/video-encoding-on-graviton-in-2025/).
 HAProxy  | 2.4+  | A [serious bug](https://github.com/haproxy/haproxy/issues/958) was fixed. Additionally, building with `CPU=armv81` improves HAProxy performance by 4x so please rebuild your code with this flag.
 MariaDB | 10.4.14+ | Default build now uses -moutline-atomics, general correctness bugs for Graviton fixed.
 mongodb | 4.2.15+ / 4.4.7+ / 5.0.0+ | Improved performance on graviton, especially for internal JS engine. LSE support added in [SERVER-56347](https://jira.mongodb.org/browse/SERVER-56347).
@@ -122,10 +126,10 @@ zlib    | zlib-ng 2.3.3+  | The original [zlib](https://github.com/madler/zlib) 
 You can run Docker, Kubernetes, Amazon ECS, and Amazon EKS on Graviton. Amazon ECR supports multi-arch containers.
 Please refer to [containers](containers.md) for information about running container-based workloads on Graviton.
 
-# [Lambda on Graviton](aws-lambda/README.md)
+# [Lambda on Graviton](aws-lambda/)
 [AWS Lambda](https://aws.amazon.com/lambda/) now allows you to configure new and existing functions to run on Arm-based AWS Graviton2 processors in addition to x86-based functions. Using this processor architecture option allows you to get up to 34% better price performance. Duration charges are 20 percent lower than the current pricing for x86 with [millisecond granularity](https://aws.amazon.com/blogs/aws/new-for-aws-lambda-1ms-billing-granularity-adds-cost-savings/). This also applies to duration charges when using [Provisioned Concurrency](https://aws.amazon.com/blogs/aws/new-provisioned-concurrency-for-lambda-functions/). Compute [Savings Plans](https://aws.amazon.com/blogs/aws/savings-plan-update-save-up-to-17-on-your-lambda-workloads/) supports Lambda functions powered by Graviton2. For more details on Lambda's arm64 architecture support, see [Lambda instruction set architectures](https://docs.aws.amazon.com/lambda/latest/dg/foundation-arch.html).
 
-The [Lambda](aws-lambda/README.md) page highlights some of the migration considerations and also provides some simple to deploy demos you can use to explore how to build and migrate to Lambda functions using Arm/Graviton2.
+The [Lambda](aws-lambda/) page highlights some of the migration considerations and also provides some simple to deploy demos you can use to explore how to build and migrate to Lambda functions using Arm/Graviton2.
 
 # Operating Systems
 
@@ -230,12 +234,12 @@ NOTE: Linux versions of OpenJDK and current Amazon Corretto releases (Corretto 1
 
 # Tools and Agent Skills
 
-[Agent Skills](tools/skills/README.md) are portable instruction packages that AI coding assistants can follow to perform Graviton migrations. They work across 20+ platforms including Claude Code, Kiro, Cursor, Codex, Windsurf, Gemini CLI, and GitHub Copilot.
+[Agent Skills](tools/skills/) are portable instruction packages that AI coding assistants can follow to perform Graviton migrations. They work across 20+ platforms including Claude Code, Kiro, Cursor, Codex, Windsurf, Gemini CLI, and GitHub Copilot.
 
 Available skills:
  * [Java x86-to-Graviton migration](tools/skills/languages/java-x86-to-graviton/) - dependency audit, native library validation, JVM optimization, ARM64 build validation
 
-See [tools/skills/README.md](tools/skills/README.md) for installation instructions and the full catalogue.
+See [tools/skills/](tools/skills/) for installation instructions and the full catalogue.
 
 # Additional resources
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -64,7 +64,7 @@
 
 * [Overview](tools/README.md)
 * [Agent Skills](tools/skills/README.md)
-    * [Java x86-to-Graviton Migration](tools/skills/languages/java-x86-to-graviton/SKILL.md)
+    * [Java x86-to-Graviton Migration](tools/skills/languages/java-x86-to-graviton/README.md)
 
 -----------
 

--- a/arm64-assembly-optimization.md
+++ b/arm64-assembly-optimization.md
@@ -127,7 +127,7 @@ When writing assembly for arm64 or any platform, be aware that the CPU has more
 than one pipeline of different types. The types and quantities are outlined in
 the Software Optimization Guide, often abbreviated as SWOG. The guide
 for each Graviton processor is linked from the [main page of this
-technical guide](README.md). Using this knowledge, the programmer can arrange instructions of
+technical guide](./). Using this knowledge, the programmer can arrange instructions of
 different types next to each other to take advantage of instruction level
 parallelism, ILP. For example, interleaving load instructions with vector or
 floating point instructions can keep both pipelines busy.
@@ -695,7 +695,7 @@ when it’s possible to process 16 bytes in parallel instead of just one at a
 time, the speed up can be significant.
 
 Another way to use efficient instructions is to consult the [software
-optimization guide](README.md#building-for-graviton2-graviton3-and-graviton3e).
+optimization guide](./#building-for-graviton2-graviton3-and-graviton3e).
 Many different combinations of instructions can accomplish the same result, and
 some are obviously better than others. Some instructions, like the
 absolute-difference-accumulate-long instructions (`sabal` and `uabal`) can only

--- a/howtoresources.md
+++ b/howtoresources.md
@@ -22,7 +22,7 @@ If you are just getting started with AWS Graviton-based instances, or even if yo
 * [Transforming Java applications with Amazon Q Developer](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/transform-java.html)
 * [Transforming .NET applications with Amazon Q Developer](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/transform-dotnet-IDE.html)
 * Source Code Analysis - [Porting Advisor for Graviton](https://github.com/aws/porting-advisor-for-graviton)
-* AI-Assisted Migration - [Graviton Agent Skills](tools/skills/README.md)
+* AI-Assisted Migration - [Graviton Agent Skills](tools/skills/)
 
 ### Building / Running applications on AWS Graviton
 

--- a/java.md
+++ b/java.md
@@ -34,7 +34,7 @@ This checklist summarizes portions of the Java on Graviton section and can be he
     * [Amazon-corretto-crypto-provider](https://github.com/corretto/amazon-corretto-crypto-provider) is another option that offers optimizations for a large number of cryptographic operations.
 * Application Testing & Performance Evaluation
     * Be sure to run Graviton instances “hotter”: vCPUs are mapped to physical cores instead of Hyperthreads and performance often flatlines at a much higher CPU utilization than with x86 based instances.  Testing at low levels of load can lead to misleading results.  The most realistic test results are usually achieved when testing close to breaking latency.
-    * See the [Graviton Performance Runbook](https://github.com/aws/aws-graviton-getting-started/blob/main/perfrunbook/README.md) for more info.
+    * See the [Graviton Performance Runbook](perfrunbook/) for more info.
     * [Aperf](https://github.com/aws/aperf) is a CLI tool for gathering & visualizing performance data that can be helpful.
 
 ### Java versions
@@ -285,4 +285,4 @@ $ make
 
 ### Agent Skills for Java Migration
 
-To automate the x86-to-Graviton migration process using an AI coding assistant (Claude Code, Kiro, Cursor, Codex, Windsurf, and others), use the [Java x86-to-Graviton Agent Skill](tools/skills/languages/java-x86-to-graviton/). It walks an agent through dependency auditing, native library validation, JVM flag configuration, and ARM64 build validation. See [tools/skills/README.md](tools/skills/README.md) for installation instructions.
+To automate the x86-to-Graviton migration process using an AI coding assistant (Claude Code, Kiro, Cursor, Codex, Windsurf, and others), use the [Java x86-to-Graviton Agent Skill](tools/skills/languages/java-x86-to-graviton/). It walks an agent through dependency auditing, native library validation, JVM flag configuration, and ARM64 build validation. See [tools/skills/](tools/skills/) for installation instructions.

--- a/perfrunbook/appendix.md
+++ b/perfrunbook/appendix.md
@@ -1,6 +1,6 @@
 # Appendix:
 
-[Graviton Performance Runbook toplevel](./README.md)
+[Graviton Performance Runbook toplevel](./)
 
 This Appendix contains additional information for engineers that want to go deeper on a particular topic, such as using different PMU counters to understand how the code is executing on the hardware, discussion on load generators, and additional tools to help with code observability.
 

--- a/perfrunbook/configuring_your_loadgen.md
+++ b/perfrunbook/configuring_your_loadgen.md
@@ -1,6 +1,6 @@
 # Configuring your load generator
 
-[Graviton Performance Runbook toplevel](./README.md)
+[Graviton Performance Runbook toplevel](./)
 
 The load generator setup is important to understand and verify: it generates the load that is expected.  An unknown load-generation setup can lead to not measuring the expected experiment and getting results that are hard to interpret. Below is a checklist to step through and verify the load generator is working as expected.
 

--- a/perfrunbook/configuring_your_sut.md
+++ b/perfrunbook/configuring_your_sut.md
@@ -1,6 +1,6 @@
 # Configuring your system-under-test environment
 
-[Graviton Performance Runbook toplevel](./README.md)
+[Graviton Performance Runbook toplevel](./)
 
 This section documents multiple checklists to use to verify your Graviton System-under-test (SUT) is up-to-date and as code-equivalent as possible to the systems and instances you are comparing against.   Please perform these tests on each SUT to vet your experimental setup and eliminate as many potential unknown variables as possible.
 

--- a/perfrunbook/debug_code_perf.md
+++ b/perfrunbook/debug_code_perf.md
@@ -1,6 +1,6 @@
 # Debugging performance — “What part of the code is slow?”
 
-[Graviton Performance Runbook toplevel](./README.md)
+[Graviton Performance Runbook toplevel](./)
 
 If after checking the system behavior with the sysstat tools the behavior of your code on the CPU is still different, then your next step is to generate code profiles. There are two primary types of profiles 
 

--- a/perfrunbook/debug_hw_perf.md
+++ b/perfrunbook/debug_hw_perf.md
@@ -1,6 +1,6 @@
 # Debugging performance — “What part of the hardware is slow?”
 
-[Graviton Performance Runbook toplevel](./README.md)
+[Graviton Performance Runbook toplevel](./)
 
 Sometimes, hardware, not code, is the reason for worse than expected performance. This may show up in the on-cpu profiles as every function is slightly slower on Graviton as more CPU time is consumed, but no obvious hot-spot function exists.  If this is the case, then measuring how the hardware performs can offer insight.  To do this requires counting special events in the CPU to understand which component of the CPU is bottlenecking the code from executing as fast as possible.
 

--- a/perfrunbook/debug_system_perf.md
+++ b/perfrunbook/debug_system_perf.md
@@ -1,6 +1,6 @@
 # Debugging performance — “What part of the system is slow?”
 
-[Graviton Performance Runbook toplevel](./README.md)
+[Graviton Performance Runbook toplevel](./)
 
 When debugging performance, start by measuring high level system behavior to pinpoint what part of the system performs differently when compared with a control instance.  Are the CPUs being saturated or under-saturated?  Is the network or disk behaving differently than expected?  Did a mis-configuration creep in that went undetected when validating the SUT application setup?
 

--- a/perfrunbook/defining_your_benchmark.md
+++ b/perfrunbook/defining_your_benchmark.md
@@ -1,6 +1,6 @@
 # Defining your benchmark
 
-[Graviton Performance Runbook toplevel](./README.md)
+[Graviton Performance Runbook toplevel](./)
 
 To define a benchmark there are two things to consider, the software running on the System-under-test (SUT) and how to drive load.  We recommend the software running on the SUT should be your production application. There is no better benchmark to predict performance than the actual production code.  If a synthetic proxy must be used to break dependencies of your application on external services such as authentication layers, then that proxy should be derived from the production code as much as possible.  We recommend avoiding synthetic benchmarks not related to the production code.  They are generally poor at predicting performance for another application or helping optimize it as they can over-target specific attributes of a system or exercise different bottlenecks than your application code might.
 

--- a/perfrunbook/intro_to_benchmarking.md
+++ b/perfrunbook/intro_to_benchmarking.md
@@ -1,6 +1,6 @@
 # Quick introduction to benchmarking
 
-[Graviton Performance Runbook toplevel](./README.md)
+[Graviton Performance Runbook toplevel](./)
 
 When designing an experiment to benchmark Graviton based instances against another instance type, it is key to remember the below 2 guiding principles:
 

--- a/perfrunbook/optimization_recommendation.md
+++ b/perfrunbook/optimization_recommendation.md
@@ -1,6 +1,6 @@
 # Optimizing performance
 
-[Graviton Performance Runbook toplevel](./README.md)
+[Graviton Performance Runbook toplevel](./)
 
 This section describes multiple different optimization suggestions to try on Graviton based instances to attain higher performance for your service.  Each sub-section defines some optimization recommendations that can help improve performance if you see a particular signature after measuring the performance using the previous checklists.
 

--- a/perfrunbook/references.md
+++ b/perfrunbook/references.md
@@ -1,6 +1,6 @@
 # References
 
-[Graviton Performance Runbook toplevel](./README.md)
+[Graviton Performance Runbook toplevel](./)
 
 Experimental design:
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,6 +1,6 @@
 # Tools
 
-Developer tooling that complements the existing [Graviton optimization guides](../README.md).
+Developer tooling that complements the existing [Graviton optimization guides](../).
 
 ## Contents
 
@@ -8,4 +8,4 @@ Developer tooling that complements the existing [Graviton optimization guides](.
 
 Portable instruction packages (SKILL.md format) for AI coding assistants. These skills encode Graviton migration expertise into a format that works across 20+ platforms including Claude Code, Kiro, Cursor, Codex, Windsurf, Gemini CLI, GitHub Copilot, and more.
 
-See [tools/skills/README.md](skills/README.md) for the full catalogue and usage instructions.
+See [tools/skills/](skills/) for the full catalogue and usage instructions.

--- a/tools/skills/README.md
+++ b/tools/skills/README.md
@@ -158,4 +158,4 @@ See the [skill template](_templates/SKILL.template.md) for the boilerplate struc
 4. Add a `README.md` with a human-readable overview
 5. Keep the main entry point under 500 lines — split detailed instructions into `phases/`, `references/`, or `scripts/` subdirectories
 
-Fill in language-specific details based on the existing [Graviton documentation](../../README.md) for each language.
+Fill in language-specific details based on the existing [Graviton documentation](../../) for each language.

--- a/tools/skills/languages/java-x86-to-graviton/README.md
+++ b/tools/skills/languages/java-x86-to-graviton/README.md
@@ -28,12 +28,12 @@ Then ask your AI assistant:
 
 | File | Purpose |
 |------|---------|
-| [SKILL.md](SKILL.md) | Main entry point — scope, workflow, exit criteria |
-| [phases/phase1-static-analysis.md](phases/phase1-static-analysis.md) | Dependency audit, native library scanning, code analysis |
-| [phases/phase2-resolution.md](phases/phase2-resolution.md) | ARM64-blocking fixes, JVM flags, Dockerfile updates |
-| [phases/phase3-validation.md](phases/phase3-validation.md) | ARM64 build, test, startup validation |
-| [document_references/agent-scope-boundaries.md](document_references/agent-scope-boundaries.md) | Scope guardrails and decision tree |
-| [document_references/documentation-standards.md](document_references/documentation-standards.md) | Output file format and naming conventions |
+| [SKILL.md](https://github.com/aws/aws-graviton-getting-started/blob/main/tools/skills/languages/java-x86-to-graviton/SKILL.md) | Main entry point — scope, workflow, exit criteria |
+| [phases/phase1-static-analysis.md](https://github.com/aws/aws-graviton-getting-started/blob/main/tools/skills/languages/java-x86-to-graviton/phases/phase1-static-analysis.md) | Dependency audit, native library scanning, code analysis |
+| [phases/phase2-resolution.md](https://github.com/aws/aws-graviton-getting-started/blob/main/tools/skills/languages/java-x86-to-graviton/phases/phase2-resolution.md) | ARM64-blocking fixes, JVM flags, Dockerfile updates |
+| [phases/phase3-validation.md](https://github.com/aws/aws-graviton-getting-started/blob/main/tools/skills/languages/java-x86-to-graviton/phases/phase3-validation.md) | ARM64 build, test, startup validation |
+| [document_references/agent-scope-boundaries.md](https://github.com/aws/aws-graviton-getting-started/blob/main/tools/skills/languages/java-x86-to-graviton/document_references/agent-scope-boundaries.md) | Scope guardrails and decision tree |
+| [document_references/documentation-standards.md](https://github.com/aws/aws-graviton-getting-started/blob/main/tools/skills/languages/java-x86-to-graviton/document_references/documentation-standards.md) | Output file format and naming conventions |
 
 ## Output
 

--- a/transition-guide.md
+++ b/transition-guide.md
@@ -47,7 +47,7 @@ The following transition guide is organized into a logical sequence of steps as 
 
 1. [Optional] Start by watching [re:Invent 2024 - AWS Graviton: The best price performance for your AWS workloads](https://www.youtube.com/watch?v=W4dnUvJJ_Sg), [re:Invent 2024 - Dive deep into the AWS Nitro System](https://www.youtube.com/watch?v=YKZbNcOU77c) and [re:Invent 2021 - Deep dive into AWS Graviton3 and Amazon EC2 C7g instances](https://www.youtube.com/watch?v=WDKwwFQKfSI), which will give you an overview of the Graviton-based instances and some insights on how to run applications depending on their operating system, languages and runtimes.
 2. [Optional] Keep on learning by watching [AWS Summit SF 2022 - The journey of silicon innovation at AWS](https://www.youtube.com/watch?v=p62DLuSCNOw) to better understand Amazon long-term commitment to innovate with custom silicon.
-3. Get familiar with the rest of this [Getting started with AWS Graviton repository](README.md) which will act as a useful reference throughout your workload transition.
+3. Get familiar with the rest of this [Getting started with AWS Graviton repository](./) which will act as a useful reference throughout your workload transition.
 
 
 **Step 2 -  Explore your workload, and inventory your current software stack**
@@ -97,7 +97,7 @@ To transition and test your application, you will need a suitable Graviton envir
 
 Note: If you are not building your application or component parts of your overall application stack you may skip this step.
 
-For applications built using interpreted or JIT’d languages, including Java, PHP or Node.js, they should run as-is or with only minor modifications. The repository contains language specific sections with recommendations, for example [Java](java.md), [Python](python.md), [C/C++](c-c++.md), [Golang](golang.md), [PHP](php.md), [R](r.md), [Node.js](nodejs.md), [Rust](rust.md) or [.Net](dotnet.md). Note: if there is no language specific section, it is because there is no specific guidance beyond using a suitably current version of the language as documented [here](README.md#recent-software-updates-relevant-to-graviton). .NET-core is a great way to benefit from Graviton-based instances, this [blog post](https://aws.amazon.com/blogs/dotnet/powering-net-8-with-aws-graviton3-benchmarks/) covers .NET 8 performance.
+For applications built using interpreted or JIT’d languages, including Java, PHP or Node.js, they should run as-is or with only minor modifications. The repository contains language specific sections with recommendations, for example [Java](java.md), [Python](python.md), [C/C++](c-c++.md), [Golang](golang.md), [PHP](php.md), [R](r.md), [Node.js](nodejs.md), [Rust](rust.md) or [.Net](dotnet.md). Note: if there is no language specific section, it is because there is no specific guidance beyond using a suitably current version of the language as documented [here](./#recent-software-updates-relevant-to-graviton). .NET-core is a great way to benefit from Graviton-based instances, this [blog post](https://aws.amazon.com/blogs/dotnet/powering-net-8-with-aws-graviton3-benchmarks/) covers .NET 8 performance.
 
 Applications using compiled languages including C, C++ or Go, need to be compiled for the Arm64 architecture. Most modern builds (e.g. using Make) will just work when run natively on Graviton-based instances, however, you’ll find language specific compiler recommendations in this repository: [C/C++](c-c++.md), [Go](golang.md), and [Rust](rust.md).
 
@@ -121,7 +121,7 @@ One of the major differences between AWS Graviton instances and other Amazon EC2
 
 During the transition to Graviton, if you are using Amazon EC2 Auto Scaling, you may be able to increase the threshold values for the CloudWatch alarms that invoke the scaling process. This may reduce the number of EC2 instances now needed to serve a given level of demand.
 
-Important: This repository has sections dedicated to [Optimization](optimizing.md) and a [Performance Runbook](perfrunbook/README.md) for you to follow during this stage.
+Important: This repository has sections dedicated to [Optimization](optimizing.md) and a [Performance Runbook](perfrunbook/) for you to follow during this stage.
 
 If after reading the documentation in this repository and following the recommendations you do not observe expected performance then please reach out to your AWS account team, or send email to [ec2-arm-dev-feedback@amazon.com](mailto:ec2-arm-dev-feedback@amazon.com) with details so we can assist you with your performance observations.
 


### PR DESCRIPTION
## Descriptions:

* Add recommendation to using APerf at the top of the "Monitoring tools for AWS Graviton" section
* Fix all broken references (links) to the section's overview page. `README.md` should not be used in the links.
* Change links to the skills in "Java x86-to-Graviton Migration Skill" to github file links - as they otherwise needed to be added in the table of contents in `SUMMARY.md`, which could make it too crowded.

## Tests

Tested locally through `mdbook serve`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
